### PR TITLE
chore: update repository URLs to Forge-Space/UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,13 @@
     "next-themes": "^0.4.6",
     "react-hook-form": "^7.71.1",
     "zod": "^4.3.6"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Forge-Space/UI.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Forge-Space/UI/issues"
+  },
+  "homepage": "https://github.com/Forge-Space/UI#readme"
 }


### PR DESCRIPTION
Updates `repository`, `bugs`, and `homepage` URLs in `package.json` to reflect the new `Forge-Space/UI` location after org transfer.