### PR TITLE
fix(ci): fix snyk-security.yml for turborepo monorepo structure

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -26,12 +26,10 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
-        cache-dependency-path: apps/${{ matrix.app }}/package-lock.json
-        
+        cache-dependency-path: package-lock.json
+
     - name: Install dependencies
-      run: |
-        cd apps/${{ matrix.app }}
-        npm ci
+      run: npm ci --legacy-peer-deps
         
     - name: Run Snyk to check for vulnerabilities
       uses: snyk/actions/node@master


### PR DESCRIPTION
## Summary
- Fix `cache-dependency-path` to use root `package-lock.json` instead of `apps/${{ matrix.app }}/package-lock.json` (individual app directories don't have their own lockfiles in this turborepo workspace setup)
- Fix `npm ci` to run at root instead of inside app subdirectory
- Add `--legacy-peer-deps` for peer dependency compatibility

This was causing `Setup Node.js` to fail with "file not found" for the per-app lockfile path.

## Test plan
- [ ] Snyk security scanning jobs should complete without "Setup Node.js" failures
- [ ] `npm ci` at root installs all workspace dependencies

https://claude.ai/code/session_01R3qsCb16LwFRoaBxt7BvWQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal dependency installation workflow configuration.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal build and testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->