### PR TITLE
fix(ci): remove local file:../forge-patterns dep breaking npm ci; fix deploy-web.yml Node 18 and wrong cache path

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -25,13 +25,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
-          cache-dependency-path: 'apps/web/package-lock.json'
+          cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        working-directory: apps/web
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Run tests
         working-directory: apps/web
@@ -74,13 +73,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
-          cache-dependency-path: 'apps/web/package-lock.json'
+          cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        working-directory: apps/web
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build application
         working-directory: apps/web

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     ]
   },
   "devDependencies": {
-    "@uiforge/forge-patterns": "file:../forge-patterns",
     "@commitlint/cli": "^20.4.1",
     "@commitlint/config-conventional": "^20.4.1",
     "@types/crypto-js": "^4.2.2",


### PR DESCRIPTION
## Summary

- `package.json`: remove `@uiforge/forge-patterns: file:../forge-patterns` from devDependencies — this path points outside the repository and causes `npm ci` to fail in all clean CI checkouts
- `deploy-web.yml`: upgrade Node 18 (EOL, below `engines: node >=22` requirement) to Node 22 in both `deploy` and `deploy-preview` jobs
- `deploy-web.yml`: fix `cache-dependency-path: apps/web/package-lock.json` (file does not exist in turborepo monorepo) to `package-lock.json` (root)
- `deploy-web.yml`: run `npm ci --legacy-peer-deps` at repo root instead of `npm ci` inside `apps/web` which has no lockfile

## Test plan
- [ ] Verify `npm ci --legacy-peer-deps` succeeds in CI
- [ ] Verify `deploy-web.yml` lints cleanly