### PR TITLE
fix: Sync package-lock.json with workspace packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "uiforge-webapp",
+  "name": "siza-webapp",
   "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "uiforge-webapp",
+      "name": "siza-webapp",
       "version": "0.2.1",
       "license": "MIT",
       "workspaces": [
@@ -86,7 +86,7 @@
       }
     },
     "apps/api": {
-      "name": "@uiforge/api",
+      "name": "@siza/api",
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.33.0",
@@ -417,7 +417,7 @@
       }
     },
     "apps/web": {
-      "name": "@uiforge/web",
+      "name": "@siza/web",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -439,6 +439,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "crypto-js": "^4.2.0",
+        "framer-motion": "^12.34.3",
         "lucide-react": "^0.469.0",
         "next": "^16.1.5",
         "react": "^19.0.0",
@@ -4374,6 +4375,18 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@siza/api": {
+      "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@siza/eslint-config": {
+      "resolved": "packages/eslint-config",
+      "link": true
+    },
+    "node_modules/@siza/web": {
+      "resolved": "apps/web",
+      "link": true
+    },
     "node_modules/@speed-highlight/core": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
@@ -5385,18 +5398,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/@uiforge/api": {
-      "resolved": "apps/api",
-      "link": true
-    },
-    "node_modules/@uiforge/eslint-config": {
-      "resolved": "packages/eslint-config",
-      "link": true
-    },
-    "node_modules/@uiforge/web": {
-      "resolved": "apps/web",
-      "link": true
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -9208,6 +9209,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
+      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -12561,6 +12589,21 @@
         "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -17545,7 +17588,7 @@
       }
     },
     "packages/eslint-config": {
-      "name": "@uiforge/eslint-config",
+      "name": "@siza/eslint-config",
       "version": "0.1.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^7.0.0",


### PR DESCRIPTION
## Summary

- Regenerate `package-lock.json` to sync with `@siza/*` workspace package names and `framer-motion` upgrade
- Fixes all CI failures (`npm ci` was failing due to missing packages in lock file)

## Test plan

- [x] `npm ci` succeeds locally after this change
- [ ] CI checks should all pass now