### PR TITLE
feat: RAG foundation with pgvector embeddings and progressive learning

### DIFF
--- a/apps/web/src/app/(dashboard)/generate/generate-client.tsx
+++ b/apps/web/src/app/(dashboard)/generate/generate-client.tsx
@@ -9,6 +9,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, Code, Github, Loader2, Check, AlertTriangle } from 'lucide-react';
+import FeedbackPanel from '@/components/generator/FeedbackPanel';
 
 function GeneratePageClient() {
   const searchParams = useSearchParams();
@@ -28,6 +29,8 @@ function GeneratePageClient() {
   );
   const [prUrl, setPrUrl] = useState<string | null>(null);
   const [pushError, setPushError] = useState<string | null>(null);
+  const [generationId, setGenerationId] = useState<string | null>(null);
+  const [ragEnriched, setRagEnriched] = useState(false);
 
   // Handle template instantiation
   useEffect(() => {
@@ -56,7 +59,14 @@ export default function ${template.replace(/[^a-zA-Z0-9]/g, '')}Component() {
     }
   }, [template, description, framework, componentLibrary]);
 
-  const handleGenerate = async (code: string, settings?: { componentName?: string }) => {
+  const handleGenerate = async (
+    code: string,
+    settings?: {
+      componentName?: string;
+      generationId?: string;
+      ragEnriched?: boolean;
+    }
+  ) => {
     setGeneratedCode(code);
     setIsGenerating(false);
     setIsTemplateMode(false);
@@ -64,6 +74,8 @@ export default function ${template.replace(/[^a-zA-Z0-9]/g, '')}Component() {
     setPrUrl(null);
     setPushError(null);
     if (settings?.componentName) setComponentName(settings.componentName);
+    setGenerationId(settings?.generationId ?? null);
+    setRagEnriched(settings?.ragEnriched ?? false);
   };
 
   const handlePushToGitHub = async () => {
@@ -223,46 +235,49 @@ export default function ${template.replace(/[^a-zA-Z0-9]/g, '')}Component() {
         </div>
       </div>
 
-      {/* Push to GitHub bar */}
+      {/* Actions bar: Feedback + Push to GitHub */}
       {generatedCode && !isGenerating && (
-        <div className="mt-4 flex items-center gap-3 p-3 rounded-lg border bg-card">
-          {pushState === 'idle' && (
-            <Button onClick={handlePushToGitHub} variant="outline" size="sm">
-              <Github className="mr-2 h-4 w-4" />
-              Push to GitHub
-            </Button>
-          )}
-          {pushState === 'pushing' && (
-            <Button disabled variant="outline" size="sm">
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Creating PR...
-            </Button>
-          )}
-          {pushState === 'success' && prUrl && (
-            <div className="flex items-center gap-2 text-sm">
-              <Check className="h-4 w-4 text-green-500" />
-              <span>PR created!</span>
-              <a
-                href={prUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary underline"
-              >
-                View on GitHub
-              </a>
-            </div>
-          )}
-          {(pushState === 'error' || pushState === 'no-repo') && (
-            <div className="flex items-center gap-2 text-sm">
-              <AlertTriangle className="h-4 w-4 text-yellow-500" />
-              <span className="text-muted-foreground">{pushError}</span>
-              {pushState === 'error' && (
-                <Button onClick={handlePushToGitHub} variant="ghost" size="sm">
-                  Retry
-                </Button>
-              )}
-            </div>
-          )}
+        <div className="mt-4 flex items-center justify-between gap-3 p-3 rounded-lg border bg-card">
+          <FeedbackPanel generationId={generationId} ragEnriched={ragEnriched} />
+          <div className="flex items-center gap-3">
+            {pushState === 'idle' && (
+              <Button onClick={handlePushToGitHub} variant="outline" size="sm">
+                <Github className="mr-2 h-4 w-4" />
+                Push to GitHub
+              </Button>
+            )}
+            {pushState === 'pushing' && (
+              <Button disabled variant="outline" size="sm">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating PR...
+              </Button>
+            )}
+            {pushState === 'success' && prUrl && (
+              <div className="flex items-center gap-2 text-sm">
+                <Check className="h-4 w-4 text-green-500" />
+                <span>PR created!</span>
+                <a
+                  href={prUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  View on GitHub
+                </a>
+              </div>
+            )}
+            {(pushState === 'error' || pushState === 'no-repo') && (
+              <div className="flex items-center gap-2 text-sm">
+                <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                <span className="text-muted-foreground">{pushError}</span>
+                {pushState === 'error' && (
+                  <Button onClick={handlePushToGitHub} variant="ghost" size="sm">
+                    Retry
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/app/api/generations/[id]/route.ts
+++ b/apps/web/src/app/api/generations/[id]/route.ts
@@ -88,6 +88,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
       'style',
       'typescript',
       'generation_time_ms',
+      'quality_score',
+      'user_feedback',
     ];
     const updates: any = {
       updated_at: new Date().toISOString(),

--- a/apps/web/src/components/generator/FeedbackPanel.tsx
+++ b/apps/web/src/components/generator/FeedbackPanel.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ThumbsUp, ThumbsDown, Sparkles } from 'lucide-react';
+
+interface FeedbackPanelProps {
+  generationId: string | null;
+  ragEnriched?: boolean;
+}
+
+export default function FeedbackPanel({ generationId, ragEnriched }: FeedbackPanelProps) {
+  const [feedback, setFeedback] = useState<'none' | 'positive' | 'negative' | 'submitted'>('none');
+
+  if (!generationId) return null;
+
+  const submitFeedback = async (score: number, text?: string) => {
+    try {
+      await fetch(`/api/generations/${generationId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          quality_score: score,
+          user_feedback: text,
+        }),
+      });
+      setFeedback('submitted');
+    } catch {
+      // Feedback is non-critical
+    }
+  };
+
+  if (feedback === 'submitted') {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <span>Thanks for your feedback!</span>
+        {ragEnriched && (
+          <span className="flex items-center gap-1 text-xs">
+            <Sparkles className="h-3 w-3" />
+            RAG-enhanced
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-muted-foreground">Rate this generation:</span>
+      <div className="flex gap-1">
+        <Button
+          variant={feedback === 'positive' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => {
+            setFeedback('positive');
+            submitFeedback(1.0, 'thumbs_up');
+          }}
+        >
+          <ThumbsUp className="h-4 w-4" />
+        </Button>
+        <Button
+          variant={feedback === 'negative' ? 'destructive' : 'ghost'}
+          size="sm"
+          onClick={() => {
+            setFeedback('negative');
+            submitFeedback(0.3, 'thumbs_down');
+          }}
+        >
+          <ThumbsDown className="h-4 w-4" />
+        </Button>
+      </div>
+      {ragEnriched && (
+        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+          <Sparkles className="h-3 w-3" />
+          RAG-enhanced
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/services/context-enrichment.ts
+++ b/apps/web/src/lib/services/context-enrichment.ts
@@ -1,0 +1,86 @@
+import { TaskType } from '@google/generative-ai';
+import {
+  generateEmbedding,
+  findSimilarGenerations,
+  findSimilarPatterns,
+  type SimilarGeneration,
+  type SimilarPattern,
+} from './embeddings';
+
+export interface EnrichmentContext {
+  similarGenerations: SimilarGeneration[];
+  similarPatterns: SimilarPattern[];
+  systemPromptAddition: string;
+}
+
+export interface EnrichmentOptions {
+  maxGenerations?: number;
+  maxPatterns?: number;
+  minQuality?: number;
+  generationThreshold?: number;
+  patternThreshold?: number;
+  framework?: string;
+  apiKey?: string;
+}
+
+export async function enrichPromptWithContext(
+  prompt: string,
+  options?: EnrichmentOptions
+): Promise<EnrichmentContext> {
+  const queryEmbedding = await generateEmbedding(prompt, TaskType.RETRIEVAL_QUERY, options?.apiKey);
+
+  const [generations, patterns] = await Promise.all([
+    findSimilarGenerations(queryEmbedding, {
+      limit: options?.maxGenerations ?? 3,
+      minQuality: options?.minQuality ?? 0.7,
+      threshold: options?.generationThreshold ?? 0.7,
+    }),
+    findSimilarPatterns(queryEmbedding, {
+      limit: options?.maxPatterns ?? 2,
+      threshold: options?.patternThreshold ?? 0.5,
+    }),
+  ]);
+
+  const filtered = options?.framework
+    ? {
+        generations: generations.filter((g) => g.framework === options.framework),
+        patterns: patterns.filter((p) => p.framework === options.framework),
+      }
+    : { generations, patterns };
+
+  const systemPromptAddition = buildContextBlock(filtered.generations, filtered.patterns);
+
+  return {
+    similarGenerations: filtered.generations,
+    similarPatterns: filtered.patterns,
+    systemPromptAddition,
+  };
+}
+
+function buildContextBlock(generations: SimilarGeneration[], patterns: SimilarPattern[]): string {
+  if (generations.length === 0 && patterns.length === 0) return '';
+
+  const parts: string[] = [];
+  parts.push('Use the following examples as reference for style and quality:');
+
+  for (const gen of generations) {
+    parts.push(`\n--- Past Generation (quality: ${gen.quality_score}) ---`);
+    parts.push(`Prompt: ${gen.prompt}`);
+    parts.push(`Code:\n${truncateCode(gen.generated_code, 1500)}`);
+  }
+
+  for (const pat of patterns) {
+    parts.push(`\n--- Pattern: ${pat.name} (${pat.category}) ---`);
+    parts.push(`Description: ${pat.description}`);
+    parts.push(`Code:\n${truncateCode(pat.code, 1500)}`);
+  }
+
+  parts.push('\nGenerate code that matches or exceeds the quality ' + 'of these examples.');
+
+  return parts.join('\n');
+}
+
+function truncateCode(code: string, maxLength: number): string {
+  if (code.length <= maxLength) return code;
+  return code.slice(0, maxLength) + '\n// ... (truncated)';
+}

--- a/apps/web/src/lib/services/embeddings.ts
+++ b/apps/web/src/lib/services/embeddings.ts
@@ -1,0 +1,106 @@
+import { GoogleGenerativeAI, TaskType } from '@google/generative-ai';
+import { createClient } from '@/lib/supabase/server';
+
+const EMBEDDING_MODEL = 'gemini-embedding-001';
+
+export interface SimilarGeneration {
+  id: string;
+  prompt: string;
+  generated_code: string;
+  framework: string;
+  quality_score: number;
+  similarity: number;
+}
+
+export interface SimilarPattern {
+  id: string;
+  name: string;
+  category: string;
+  description: string;
+  code: string;
+  framework: string;
+  similarity: number;
+}
+
+export async function generateEmbedding(
+  text: string,
+  taskType: TaskType = TaskType.RETRIEVAL_DOCUMENT,
+  apiKey?: string
+): Promise<number[]> {
+  const key = apiKey || process.env.GEMINI_API_KEY;
+  if (!key) throw new Error('Gemini API key required for embeddings');
+
+  const genAI = new GoogleGenerativeAI(key);
+  const model = genAI.getGenerativeModel({ model: EMBEDDING_MODEL });
+  const result = await model.embedContent({
+    content: { role: 'user', parts: [{ text }] },
+    taskType,
+  });
+  return result.embedding.values;
+}
+
+export async function findSimilarGenerations(
+  queryEmbedding: number[],
+  options?: {
+    threshold?: number;
+    limit?: number;
+    minQuality?: number;
+  }
+): Promise<SimilarGeneration[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc('match_generations', {
+    query_embedding: `[${queryEmbedding.join(',')}]`,
+    match_threshold: options?.threshold ?? 0.7,
+    match_count: options?.limit ?? 5,
+    min_quality: options?.minQuality ?? 0.7,
+  });
+
+  if (error) throw error;
+  return (data as SimilarGeneration[]) ?? [];
+}
+
+export async function findSimilarPatterns(
+  queryEmbedding: number[],
+  options?: { threshold?: number; limit?: number }
+): Promise<SimilarPattern[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc('match_patterns', {
+    query_embedding: `[${queryEmbedding.join(',')}]`,
+    match_threshold: options?.threshold ?? 0.5,
+    match_count: options?.limit ?? 3,
+  });
+
+  if (error) throw error;
+  return (data as SimilarPattern[]) ?? [];
+}
+
+export async function storeGenerationEmbedding(
+  generationId: string,
+  prompt: string,
+  apiKey?: string
+): Promise<void> {
+  const embedding = await generateEmbedding(prompt, TaskType.RETRIEVAL_DOCUMENT, apiKey);
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from('generations')
+    .update({
+      prompt_embedding: `[${embedding.join(',')}]` as unknown as string,
+    })
+    .eq('id', generationId);
+
+  if (error) throw error;
+}
+
+export async function updateQualityScore(
+  generationId: string,
+  score: number,
+  feedback?: string
+): Promise<void> {
+  const supabase = await createClient();
+  const update: Record<string, unknown> = { quality_score: score };
+  if (feedback !== undefined) update.user_feedback = feedback;
+
+  const { error } = await supabase.from('generations').update(update).eq('id', generationId);
+
+  if (error) throw error;
+}

--- a/apps/web/src/lib/services/gemini.ts
+++ b/apps/web/src/lib/services/gemini.ts
@@ -14,6 +14,7 @@ export interface GeminiGenerateOptions {
   style?: string;
   typescript?: boolean;
   apiKey?: string;
+  contextAddition?: string;
 }
 
 const SYSTEM_PROMPT = `You are a UI component generator. Generate a single, self-contained React component.
@@ -62,9 +63,12 @@ export async function* generateComponentStream(
 
   try {
     const genAI = new GoogleGenerativeAI(apiKey);
+    const systemPrompt = options.contextAddition
+      ? `${SYSTEM_PROMPT}\n\n${options.contextAddition}`
+      : SYSTEM_PROMPT;
     const model = genAI.getGenerativeModel({
       model: 'gemini-2.0-flash',
-      systemInstruction: SYSTEM_PROMPT,
+      systemInstruction: systemPrompt,
     });
 
     const userPrompt = buildPrompt(options);

--- a/supabase/migrations/20260224000002_rag_embeddings.sql
+++ b/supabase/migrations/20260224000002_rag_embeddings.sql
@@ -1,0 +1,126 @@
+-- RAG Foundation: pgvector embeddings for progressive learning
+-- Enables semantic search over past generations and component patterns
+
+create extension if not exists vector;
+
+-- Add embedding + quality columns to generations
+alter table public.generations
+  add column if not exists prompt_embedding vector(3072),
+  add column if not exists quality_score float,
+  add column if not exists user_feedback text;
+
+alter table public.generations
+  add constraint quality_score_range
+  check (quality_score is null or (quality_score >= 0 and quality_score <= 1));
+
+-- Add embedding column to components
+alter table public.components
+  add column if not exists embedding vector(3072);
+
+-- Component patterns library (curated few-shot examples)
+create table if not exists public.component_patterns (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  category text not null,
+  description text not null,
+  code text not null,
+  framework text not null,
+  embedding vector(3072),
+  usage_count integer default 0,
+  avg_quality_score float,
+  created_at timestamptz default now()
+);
+
+alter table public.component_patterns enable row level security;
+
+create policy "Patterns are readable by authenticated users"
+  on public.component_patterns for select
+  to authenticated
+  using (true);
+
+-- IVFFlat indexes for cosine similarity (efficient for < 1M rows)
+create index if not exists generations_embedding_idx
+  on public.generations
+  using ivfflat (prompt_embedding vector_cosine_ops)
+  with (lists = 100);
+
+create index if not exists components_embedding_idx
+  on public.components
+  using ivfflat (embedding vector_cosine_ops)
+  with (lists = 100);
+
+create index if not exists patterns_embedding_idx
+  on public.component_patterns
+  using ivfflat (embedding vector_cosine_ops)
+  with (lists = 100);
+
+-- Index on quality_score for filtering high-quality examples
+create index if not exists generations_quality_idx
+  on public.generations (quality_score desc)
+  where quality_score is not null and quality_score > 0.7;
+
+-- Similarity search function for generations
+create or replace function public.match_generations(
+  query_embedding vector(3072),
+  match_threshold float default 0.7,
+  match_count int default 5,
+  min_quality float default 0.7
+)
+returns table (
+  id uuid,
+  prompt text,
+  generated_code text,
+  framework text,
+  quality_score float,
+  similarity float
+)
+language sql stable
+as $$
+  select
+    g.id,
+    g.prompt,
+    g.generated_code,
+    g.framework,
+    g.quality_score,
+    1 - (g.prompt_embedding <=> query_embedding) as similarity
+  from public.generations g
+  where g.prompt_embedding is not null
+    and g.generated_code is not null
+    and g.status = 'completed'
+    and (g.quality_score is null or g.quality_score >= min_quality)
+    and 1 - (g.prompt_embedding <=> query_embedding) > match_threshold
+  order by g.prompt_embedding <=> query_embedding
+  limit match_count;
+$$;
+
+-- Similarity search function for component patterns
+create or replace function public.match_patterns(
+  query_embedding vector(3072),
+  match_threshold float default 0.5,
+  match_count int default 3
+)
+returns table (
+  id uuid,
+  name text,
+  category text,
+  description text,
+  code text,
+  framework text,
+  similarity float
+)
+language sql stable
+as $$
+  select
+    p.id,
+    p.name,
+    p.category,
+    p.description,
+    p.code,
+    p.framework,
+    1 - (p.embedding <=> query_embedding) as similarity
+  from public.component_patterns p
+  where p.embedding is not null
+    and 1 - (p.embedding <=> query_embedding) > match_threshold
+  order by p.embedding <=> query_embedding
+  limit match_count;
+$$;


### PR DESCRIPTION
## Summary
- **pgvector migration**: `vector(3072)` embedding columns on `generations` and `components` tables, `component_patterns` table for curated examples, IVFFlat cosine similarity indexes, `match_generations()` and `match_patterns()` RPC functions
- **Embeddings service**: `gemini-embedding-001` (3072 dims, free tier) with `RETRIEVAL_QUERY`/`RETRIEVAL_DOCUMENT` task types, vector search via Supabase RPCs
- **Context enrichment pipeline**: RAG retrieval of similar past generations + component patterns, injected as few-shot examples into the system prompt before generation
- **Generation route integration**: Creates DB record per generation, stores embedding asynchronously after completion, reports `ragEnriched` and `generationId` in SSE complete event
- **Feedback UI**: Thumbs up/down panel on generation result, stores `quality_score` + `user_feedback` for progressive learning loop
- **Best-effort design**: RAG enrichment and embedding storage are non-blocking — generation works fine if either fails

## Architecture
```
User Prompt → Embed (RETRIEVAL_QUERY) → pgvector search → Inject context
    → Gemini 2.0 Flash → Quality Gates → SSE Stream
    → Store result + Embed (RETRIEVAL_DOCUMENT) → Feedback → Loop
```

## Test plan
- [ ] Build passes (`npm run build --workspace=apps/web`)
- [ ] Lint passes (`npm run lint --workspace=apps/web`)
- [ ] Generation works without RAG context (cold start, no embeddings yet)
- [ ] After first generation with feedback, verify embedding stored in DB
- [ ] Second similar prompt retrieves first generation as context
- [ ] Thumbs up/down saves quality_score to generation record
- [ ] RAG enrichment failure doesn't block generation (best-effort)
- [ ] pgvector migration applies cleanly on Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)