### PR TITLE
feat: Add image recognition with Gemini Vision (Phase 3)

### DIFF
--- a/apps/web/src/app/api/analyze-image/route.ts
+++ b/apps/web/src/app/api/analyze-image/route.ts
@@ -1,0 +1,57 @@
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { verifySession } from '@/lib/api/auth';
+import { checkRateLimit } from '@/lib/api/rate-limit';
+import { analyzeDesignImage } from '@/lib/services/image-analysis';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
+
+const analyzeSchema = z.object({
+  imageBase64: z.string().min(1).max(MAX_IMAGE_SIZE, 'Image too large (max ~5MB)'),
+  mimeType: z.enum(['image/png', 'image/jpeg', 'image/webp']),
+  userApiKey: z.string().min(1).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const rateLimitResult = await checkRateLimit(request, 10, 60000);
+    if (!rateLimitResult.allowed) {
+      return new Response(
+        JSON.stringify({ error: 'Rate limit exceeded. Try again shortly.' }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    await verifySession();
+
+    const body = await request.json();
+    const parsed = analyzeSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return new Response(
+        JSON.stringify({
+          error: parsed.error.issues[0]?.message || 'Invalid request',
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { imageBase64, mimeType, userApiKey } = parsed.data;
+    const analysis = await analyzeDesignImage(imageBase64, mimeType, userApiKey);
+
+    return new Response(JSON.stringify(analysis), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Analysis failed';
+    const status = message === 'Authentication required' ? 401 : 500;
+    return new Response(JSON.stringify({ error: message }), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/apps/web/src/lib/api/generation.ts
+++ b/apps/web/src/lib/api/generation.ts
@@ -9,6 +9,8 @@ export interface GenerationOptions {
   style?: 'modern' | 'minimal' | 'colorful';
   typescript?: boolean;
   userApiKey?: string;
+  imageBase64?: string;
+  imageMimeType?: 'image/png' | 'image/jpeg' | 'image/webp';
 }
 
 export interface GenerationEvent {

--- a/apps/web/src/lib/services/gemini.ts
+++ b/apps/web/src/lib/services/gemini.ts
@@ -15,6 +15,8 @@ export interface GeminiGenerateOptions {
   typescript?: boolean;
   apiKey?: string;
   contextAddition?: string;
+  imageBase64?: string;
+  imageMimeType?: string;
 }
 
 const SYSTEM_PROMPT = `You are a UI component generator. Generate a single, self-contained React component.
@@ -72,7 +74,21 @@ export async function* generateComponentStream(
     });
 
     const userPrompt = buildPrompt(options);
-    const result = await model.generateContentStream(userPrompt);
+
+    const content =
+      options.imageBase64 && options.imageMimeType
+        ? [
+            { text: userPrompt },
+            {
+              inlineData: {
+                mimeType: options.imageMimeType,
+                data: options.imageBase64,
+              },
+            },
+          ]
+        : userPrompt;
+
+    const result = await model.generateContentStream(content);
 
     for await (const chunk of result.stream) {
       const text = chunk.text();

--- a/apps/web/src/lib/services/image-analysis.ts
+++ b/apps/web/src/lib/services/image-analysis.ts
@@ -1,0 +1,50 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+export interface DesignAnalysis {
+  layout: string;
+  components: string[];
+  colors: string[];
+  typography: string;
+  spacing: string;
+  interactions: string[];
+  suggestedPrompt: string;
+}
+
+const ANALYSIS_PROMPT = `Analyze this UI screenshot and extract design details.
+Return ONLY valid JSON with this exact structure:
+{
+  "layout": "description of the layout structure (e.g. sidebar + main content, grid, single column)",
+  "components": ["list", "of", "UI", "components", "visible"],
+  "colors": ["#hex1", "#hex2", "...primary colors used"],
+  "typography": "description of font styles, sizes, weights observed",
+  "spacing": "description of spacing patterns (tight, spacious, grid-based, etc.)",
+  "interactions": ["hover effects", "animations", "transitions observed or implied"],
+  "suggestedPrompt": "A detailed prompt that could recreate this UI as a React component"
+}`;
+
+export async function analyzeDesignImage(
+  imageBase64: string,
+  mimeType: string,
+  apiKey?: string
+): Promise<DesignAnalysis> {
+  const key = apiKey || process.env.GEMINI_API_KEY;
+  if (!key) {
+    throw new Error('Gemini API key is required');
+  }
+
+  const genAI = new GoogleGenerativeAI(key);
+  const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash' });
+
+  const result = await model.generateContent([
+    { text: ANALYSIS_PROMPT },
+    { inlineData: { mimeType, data: imageBase64 } },
+  ]);
+
+  const text = result.response.text();
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error('Failed to parse design analysis response');
+  }
+
+  return JSON.parse(jsonMatch[0]) as DesignAnalysis;
+}


### PR DESCRIPTION
## Summary

- **Gemini service**: Added `imageBase64`/`imageMimeType` to `GeminiGenerateOptions`. When an image is present, content is sent as `[text, inlineData]` array for multimodal generation. Without an image, plain string is used (backward compatible).
- **Generation route**: Extended Zod schema with optional image fields (max ~5MB, PNG/JPEG/WebP). Fields pass through to `generateComponentStream`. API version bumped to 3.0.0.
- **Image analysis service**: Standalone `analyzeDesignImage()` function that sends a screenshot to Gemini Vision and returns structured `DesignAnalysis` (layout, components, colors, typography, spacing, interactions, suggested prompt).
- **Analyze-image endpoint**: `POST /api/analyze-image` — rate-limited, authenticated endpoint returning design analysis JSON.
- **GeneratorForm UI**: Collapsible "Reference Image" section with drag-and-drop upload zone, image preview, file validation (type + size), and base64 conversion on client side.
- **Client API types**: `GenerationOptions` extended with optional `imageBase64` and `imageMimeType`.

## Test plan

- [ ] Generate component WITHOUT image — should work identically to before
- [ ] Generate component WITH image — Gemini receives multimodal content
- [ ] Upload invalid file type (e.g. .gif) — should show error
- [ ] Upload oversized file (>5MB) — should show error
- [ ] Drag-and-drop image into upload zone — should show preview
- [ ] Click to browse and select image — should show preview
- [ ] Remove attached image — should clear preview
- [ ] POST to `/api/analyze-image` with valid screenshot — should return structured analysis
- [ ] POST to `/api/analyze-image` without auth — should return 401
- [ ] Verify lint passes (`npm run lint --workspace=apps/web`)