### PR TITLE
fix: CI test and formatting fixes

### DIFF
--- a/apps/web/src/app/api/analyze-image/route.ts
+++ b/apps/web/src/app/api/analyze-image/route.ts
@@ -19,10 +19,10 @@ export async function POST(request: NextRequest) {
   try {
     const rateLimitResult = await checkRateLimit(request, 10, 60000);
     if (!rateLimitResult.allowed) {
-      return new Response(
-        JSON.stringify({ error: 'Rate limit exceeded. Try again shortly.' }),
-        { status: 429, headers: { 'Content-Type': 'application/json' } }
-      );
+      return new Response(JSON.stringify({ error: 'Rate limit exceeded. Try again shortly.' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     await verifySession();

--- a/apps/web/src/components/generator/GeneratorForm.tsx
+++ b/apps/web/src/components/generator/GeneratorForm.tsx
@@ -257,9 +257,7 @@ export default function GeneratorForm({
               <ChevronDownIcon
                 className={`h-4 w-4 transition-transform ${showImageUpload ? 'rotate-180' : ''}`}
               />
-              {image && (
-                <span className="text-xs text-green-600 font-medium ml-1">attached</span>
-              )}
+              {image && <span className="text-xs text-green-600 font-medium ml-1">attached</span>}
             </button>
 
             {showImageUpload && (
@@ -312,9 +310,7 @@ export default function GeneratorForm({
                     />
                   </button>
                 )}
-                {imageError && (
-                  <p className="mt-2 text-sm text-red-600">{imageError}</p>
-                )}
+                {imageError && <p className="mt-2 text-sm text-red-600">{imageError}</p>}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Fix generate route tests: add mocks for usage quota, supabase, context-enrichment, embeddings, and quality gates
- Fix stream race condition: consume response body before asserting mock calls
- Update version expectation from 2.0.0 to 3.0.0 (aligned with Image Recognition PR)
- Run Prettier on analyze-image/route.ts and GeneratorForm.tsx

## Test plan

- [ ] All 113 unit tests pass (verified locally)
- [ ] Prettier formatting check passes
- [ ] Build passes