### PR TITLE
chore: Sync release changes to dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,105 @@
-# Siza - AI-Powered UI Development Platform
+# siza
 
-## Structure
-Turborepo monorepo:
-- `apps/web` — Next.js 16 (App Router), React 19, TypeScript, Tailwind CSS 4
-- `apps/api` — API utilities and shared services
-- `packages/` — Shared types and utilities
+Zero-cost web application for AI-driven UI generation. Turborepo monorepo.
 
-## Deployment
-**Cloudflare Workers via OpenNext** (`@opennextjs/cloudflare@1.17.0`):
-- Config: `apps/web/wrangler.jsonc` + `apps/web/open-next.config.ts`
-- Build: `NODE_ENV=production npx opennextjs-cloudflare build` (from `apps/web/`)
-- Deploy: GitHub Actions with `cloudflare/wrangler-action@v3`
-- Unified: web + API routes served from single Worker
+## Quick Reference
 
-## Key Constraints
-- **No `setInterval`** in Workers — use lazy cleanup pattern for rate limiting
-- **No `runtime = 'nodejs'`** exports in API routes — OpenNext handles runtime automatically
-- **middleware.ts** with `runtime = 'experimental-edge'` — proxy.ts workaround (Next.js 16 proxy.ts is Node.js-only, OpenNext issue #962)
-- **`GITHUB_TOKEN` env var** overrides `gh` keyring auth — use `GITHUB_TOKEN= gh ...`
-
-## Dev Flow (Trunk-Based)
-- Branch from `dev`: `git checkout -b feat/feature-name`
-- PR to `dev` first → CI checks → merge
-- PR from `dev` → `main` → auto-deploy to Cloudflare Workers
-- Conventional commits: feat, fix, refactor, chore, docs
-
-## Key Commands
 ```bash
-npm run dev          # turbo dev (all apps)
-npm run build        # turbo build
-npm run lint         # turbo lint
-npm run test         # turbo test
-npm run test:e2e     # Playwright e2e tests
+npm run dev             # Start dev server (turbo)
+npm run build           # Build all apps (turbo)
+npm run lint            # Lint all (turbo)
+npm run format          # Prettier all
+npm run type-check      # TypeScript checking
+npm run test            # Unit tests (turbo → Jest)
+npm run test:e2e        # E2E tests (turbo → Playwright)
+```
+
+## Monorepo Structure
+
+```
+apps/
+  web/                  # Next.js frontend (@siza/web)
+    src/
+      app/              # Next.js App Router pages
+      components/       # UI components
+      hooks/            # Custom React hooks
+      lib/              # Utilities
+      stores/           # State management
+    e2e/                # Playwright E2E tests
+  api/                  # API service (@siza/api)
+packages/
+  eslint-config/        # Shared ESLint config
+supabase/
+  migrations/           # Database migrations
+  seed.sql              # Seed data
+  config.toml           # Supabase config
 ```
 
 ## Tech Stack
-- **Frontend**: Next.js 16, React 19, shadcn/ui, Radix, Tailwind CSS 4, Lucide icons
-- **Database**: Supabase (PostgreSQL + Auth + Storage + pgvector)
-- **AI**: Gemini 2.0 Flash (primary), BYOK for OpenAI/Anthropic
-- **Deployment**: Cloudflare Workers via OpenNext
 
-## Critical Paths
-- Generation route: `apps/web/src/app/api/generate/route.ts`
-- Edge middleware: `apps/web/src/middleware.ts`
-- Gemini service: `apps/web/src/lib/services/gemini.ts`
-- Rate limiter: lazy cleanup in middleware (no setInterval)
-- Supabase migrations: `supabase/migrations/`
+- **Framework**: Next.js (App Router) with Turborepo
+- **UI**: Radix UI + Tailwind CSS + shadcn/ui (class-variance-authority, clsx, lucide-react)
+- **State**: TanStack React Query + Zustand stores
+- **Auth/DB**: Supabase (SSR + client)
+- **Email**: Resend SDK + react-email templates
+- **Billing**: Stripe (Checkout, Customer Portal, Webhooks)
+- **Code Editor**: Monaco Editor
+- **AI**: Anthropic SDK, Google Generative AI, MCP SDK
+- **Testing**: Jest (unit) + Playwright (E2E)
+- **Deploy**: Cloudflare Pages (wrangler.toml)
 
-## Security
-- AES-256-GCM encryption for user API keys
-- Zod validation on all API inputs
-- RLS policies on all Supabase tables
-- No plaintext credentials in code or config
+## Architecture
+
+```
+forge-patterns → mcp-gateway → siza (this repo)
+                                  ├── web (Next.js frontend)
+                                  └── api (backend service)
+```
+
+The webapp consumes the mcp-gateway API to provide AI-powered UI generation to users. Supabase handles auth, database, and real-time features.
+
+## Key Paths
+
+- `apps/web/src/app/(auth)/` — Auth routes (signin, signup, forgot-password, reset-password)
+- `apps/web/src/app/(dashboard)/` — Dashboard routes (generate, projects, settings, billing)
+- `apps/web/src/app/(marketing)/` — Marketing/landing pages (pricing)
+- `apps/web/src/app/api/` — API routes (components, projects, generate, wireframe, stripe, features, auth, usage)
+- `apps/web/src/components/ui/` — shadcn/ui components (16+)
+- `apps/web/src/components/billing/` — Billing UI (PricingCard, SubscriptionStatus, UsageChart, UpgradePrompt)
+- `apps/web/src/lib/supabase/` — Supabase clients and types
+- `apps/web/src/lib/email/` — Resend client, email service, auth email helpers
+- `apps/web/src/lib/stripe/` — Stripe server/client SDK, plans, webhook handler
+- `apps/web/src/lib/usage/` — Usage tracking, quota checks, plan limits
+- `apps/web/src/lib/features/` — Feature flags (flags.ts, types.ts, client.ts, provider.tsx)
+- `apps/web/src/emails/` — react-email templates (verification, welcome, password reset)
+- `apps/web/src/stores/` — Zustand stores (auth, generation)
+- `apps/api/` — Cloudflare Workers API with AI provider integrations
+- `supabase/migrations/` — 10 migration files (schema, storage, templates, logging, providers, github, generation fields, embeddings, feature flags, subscriptions)
+
+## Supabase Schema
+
+11 tables with RLS: `profiles`, `projects`, `components`, `generations`, `api_keys`, `feature_flags`, `feature_flag_changes`, `subscriptions`, `plan_limits`, `usage_tracking`, `stripe_events`
+4 storage buckets: `avatars`, `project-thumbnails`, `project-files`, `user-uploads`
+Auth: Email/Password + Google/GitHub OAuth via `@supabase/ssr`
+
+## Architecture Notes
+
+- Feature flag provider wraps the app — DB-backed flags with env var fallback
+- Stripe webhook flow: Stripe → `/api/stripe/webhook` → verify signature → sync subscription state to Supabase
+- Usage limits: quota check before generation/project creation, increment after success (gated by ENABLE_USAGE_LIMITS flag)
+
+## CI/CD
+
+- GitHub Actions: ci.yml, deploy-web.yml, production.yml, release-automation.yml
+- Cloudflare Pages deployment (wrangler)
+- Supabase migrations
+- Secret scanning, npm audit security
+
+## Conventions
+
+- Turborepo for build orchestration
+- Next.js App Router (not Pages)
+- Radix + Tailwind + shadcn/ui component pattern
+- Supabase SSR auth (`@supabase/ssr`)
+- Conventional commits
+- Trunk-based development

--- a/apps/web/src/app/api/analyze-image/route.ts
+++ b/apps/web/src/app/api/analyze-image/route.ts
@@ -18,10 +18,10 @@ export async function POST(request: NextRequest) {
   try {
     const rateLimitResult = await checkRateLimit(request, 10, 60000);
     if (!rateLimitResult.allowed) {
-      return new Response(
-        JSON.stringify({ error: 'Rate limit exceeded. Try again shortly.' }),
-        { status: 429, headers: { 'Content-Type': 'application/json' } }
-      );
+      return new Response(JSON.stringify({ error: 'Rate limit exceeded. Try again shortly.' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     await verifySession();

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -7,6 +7,8 @@ import { runAllGates } from '@/lib/quality/gates';
 import { enrichPromptWithContext } from '@/lib/services/context-enrichment';
 import { storeGenerationEmbedding } from '@/lib/services/embeddings';
 import { createClient } from '@/lib/supabase/server';
+import { checkGenerationQuota } from '@/lib/usage/limits';
+import { incrementGenerationCount } from '@/lib/usage/tracker';
 
 export const dynamic = 'force-dynamic';
 
@@ -37,6 +39,21 @@ export async function POST(request: NextRequest) {
     }
 
     const { user } = await verifySession();
+
+    const quota = await checkGenerationQuota(user.id);
+    if (!quota.allowed) {
+      return new Response(
+        JSON.stringify({
+          error: 'Generation quota exceeded',
+          quota: {
+            current: quota.current,
+            limit: quota.limit,
+            remaining: quota.remaining,
+          },
+        }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
 
     const body = await request.json();
     const parsed = generateSchema.safeParse(body);
@@ -136,6 +153,7 @@ export async function POST(request: NextRequest) {
                   .eq('id', generationId);
 
                 storeGenerationEmbedding(generationId, description, userApiKey).catch(() => {});
+                incrementGenerationCount(user.id).catch(() => {});
               }
 
               controller.enqueue(

--- a/apps/web/src/components/generator/GeneratorForm.tsx
+++ b/apps/web/src/components/generator/GeneratorForm.tsx
@@ -257,9 +257,7 @@ export default function GeneratorForm({
               <ChevronDownIcon
                 className={`h-4 w-4 transition-transform ${showImageUpload ? 'rotate-180' : ''}`}
               />
-              {image && (
-                <span className="text-xs text-green-600 font-medium ml-1">attached</span>
-              )}
+              {image && <span className="text-xs text-green-600 font-medium ml-1">attached</span>}
             </button>
 
             {showImageUpload && (
@@ -312,9 +310,7 @@ export default function GeneratorForm({
                     />
                   </button>
                 )}
-                {imageError && (
-                  <p className="mt-2 text-sm text-red-600">{imageError}</p>
-                )}
+                {imageError && <p className="mt-2 text-sm text-red-600">{imageError}</p>}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Wire usage quotas into generate and projects API routes
- Add test mocks for usage quota, supabase, context-enrichment, embeddings, quality gates
- Fix stream race condition in tests (consume body before asserting mock calls)
- Update version expectation from 2.0.0 to 3.0.0
- Run Prettier on analyze-image/route.ts and GeneratorForm.tsx
- Add CLAUDE.md with updated paths, tables, tech stack

Syncs changes from release/resend-flags-billing that were merged to main via PR #33.

## Test plan

- [x] Generate route tests: 7/7 passing
- [x] Prettier formatting clean
- [x] Pre-commit gate passes (lint + type-check)