### PR TITLE
chore: Set test coverage baseline thresholds

### DIFF
--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -27,10 +27,10 @@ const customJestConfig = {
   ],
   coverageThreshold: {
     global: {
-      branches: 0,
-      functions: 0,
-      lines: 0,
-      statements: 0,
+      branches: 4,
+      functions: 5,
+      lines: 11,
+      statements: 11,
     },
   },
 };


### PR DESCRIPTION
## Summary
Sets coverage thresholds slightly below current levels to prevent regression while allowing headroom for development.

### Current Coverage
- Statements: 11.72% → threshold: 11%
- Branches: 4.69% → threshold: 4%
- Functions: 5.68% → threshold: 5%
- Lines: 12.05% → threshold: 11%

### Rationale
- Establishes baseline to prevent coverage regression
- Critical paths are well-tested (generate: 87%, gemini: 93%, rate-limit: 100%)
- Allows headroom for refactoring without blocking builds
- Tests pass with new thresholds

### Testing
- All tests pass: 13 test suites, 113 tests
- No coverage regressions