### PR TITLE
fix: Remove all dark: prefix leftovers and duplicate CSS classes

### DIFF
--- a/apps/web/src/app/(dashboard)/generate/generate-client.tsx
+++ b/apps/web/src/app/(dashboard)/generate/generate-client.tsx
@@ -195,12 +195,10 @@ export default function TemplateComponent() {
         </div>
 
         {isTemplateMode && (
-          <div className="mt-4 p-3 bg-brand/10 bg-brand-muted border border-brand/30 dark:border-blue-800 rounded-lg">
+          <div className="mt-4 p-3 bg-brand-muted border border-brand/30 rounded-lg">
             <div className="flex items-center gap-2">
-              <Code className="w-4 h-4 text-brand text-text-brand" />
-              <span className="text-sm font-medium text-text-brand dark:text-text-brand">
-                Template Mode: {template}
-              </span>
+              <Code className="w-4 h-4 text-text-brand" />
+              <span className="text-sm font-medium text-text-brand">Template Mode: {template}</span>
               <Badge variant="secondary" className="text-xs">
                 {framework}
               </Badge>
@@ -208,7 +206,7 @@ export default function TemplateComponent() {
                 {componentLibrary}
               </Badge>
             </div>
-            <p className="text-xs text-brand dark:text-text-brand mt-1">
+            <p className="text-xs text-text-brand mt-1">
               This template has been pre-loaded. You can customize it further or generate new
               components.
             </p>

--- a/apps/web/src/app/(marketing)/docs/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/page.tsx
@@ -19,7 +19,7 @@ export default function DocsPage() {
   return (
     <div className="min-h-screen">
       {/* Hero Section */}
-      <section className="bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950 dark:to-purple-950 py-20">
+      <section className="bg-gradient-to-br from-blue-950 to-purple-950 py-20">
         <div className="max-w-6xl mx-auto px-6">
           <div className="text-center">
             <Badge className="mb-4">Documentation</Badge>
@@ -95,7 +95,7 @@ export default function DocsPage() {
       </section>
 
       {/* Documentation Sections */}
-      <section className="py-16 bg-muted dark:bg-background">
+      <section className="py-16 bg-background">
         <div className="max-w-6xl mx-auto px-6">
           <h2 className="text-3xl font-bold text-center mb-12">Documentation</h2>
 
@@ -182,7 +182,7 @@ export default function DocsPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
             <Card className="p-6">
               <h3 className="text-xl font-semibold mb-4">Basic Component Generation</h3>
-              <div className="bg-muted dark:bg-secondary rounded-lg p-4 font-mono text-sm">
+              <div className="bg-secondary rounded-lg p-4 font-mono text-sm">
                 <pre>{`// Generate a button component
 const response = await fetch('/api/generate', {
   method: 'POST',
@@ -198,7 +198,7 @@ const response = await fetch('/api/generate', {
 
             <Card className="p-6">
               <h3 className="text-xl font-semibold mb-4">Using Templates</h3>
-              <div className="bg-muted dark:bg-secondary rounded-lg p-4 font-mono text-sm">
+              <div className="bg-secondary rounded-lg p-4 font-mono text-sm">
                 <pre>{`// Use a pre-built template
 const template = await fetch('/api/templates/navigation-bar');
 const component = instantiateTemplate(template, {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -123,7 +123,7 @@ export default async function HomePage() {
           </div>
         </section>
 
-        <section className="border-t bg-gradient-to-b from-surface-0 to-surface-1 dark:from-purple-950/20 dark:to-purple-900/20 py-24">
+        <section className="border-t bg-gradient-to-b from-purple-950/20 to-purple-900/20 py-24">
           <div className="container mx-auto px-4">
             <h2 className="mb-4 text-center text-sm font-medium uppercase tracking-widest text-muted-foreground">
               Why Siza

--- a/apps/web/src/components/analytics/AnalyticsDashboard.tsx
+++ b/apps/web/src/components/analytics/AnalyticsDashboard.tsx
@@ -107,7 +107,7 @@ export default function AnalyticsDashboard() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <div className="flex bg-surface-1 bg-surface-2 rounded-lg p-1">
+          <div className="flex bg-surface-2 rounded-lg p-1">
             {(['7d', '30d', '90d'] as const).map((range) => (
               <Button
                 key={range}
@@ -252,7 +252,7 @@ export default function AnalyticsDashboard() {
               <div key={index} className="flex items-center justify-between">
                 <span className="text-sm">{browser.browser}</span>
                 <div className="flex items-center gap-2">
-                  <div className="w-24 bg-surface-2 dark:bg-surface-3 rounded-full h-2">
+                  <div className="w-24 bg-surface-3 rounded-full h-2">
                     <div
                       className="bg-brand h-2 rounded-full"
                       style={{ width: `${browser.percentage}%` }}
@@ -278,7 +278,7 @@ export default function AnalyticsDashboard() {
               <div key={index} className="flex items-center justify-between">
                 <span className="text-sm">{device.device}</span>
                 <div className="flex items-center gap-2">
-                  <div className="w-24 bg-surface-2 dark:bg-surface-3 rounded-full h-2">
+                  <div className="w-24 bg-surface-3 rounded-full h-2">
                     <div
                       className="bg-green-600 h-2 rounded-full"
                       style={{ width: `${device.percentage}%` }}

--- a/apps/web/src/components/analytics/CustomDomain.tsx
+++ b/apps/web/src/components/analytics/CustomDomain.tsx
@@ -131,7 +131,7 @@ export default function CustomDomain() {
               {domain.dnsRecords && (
                 <div className="mt-4">
                   <h4 className="text-sm font-medium mb-2">DNS Records:</h4>
-                  <div className="bg-surface-0 bg-surface-2 rounded p-3">
+                  <div className="bg-surface-2 rounded p-3">
                     <div className="space-y-2 text-sm">
                       {domain.dnsRecords.map((record, recordIndex) => (
                         <div key={recordIndex} className="font-mono">
@@ -151,8 +151,8 @@ export default function CustomDomain() {
 
               {/* Instructions */}
               {domain.status === 'pending' && (
-                <div className="mt-4 p-3 bg-brand/10 bg-brand-muted border border-brand/30 dark:border-blue-800 rounded">
-                  <p className="text-sm text-text-brand dark:text-text-brand">
+                <div className="mt-4 p-3 bg-brand-muted border border-brand/30 rounded">
+                  <p className="text-sm text-text-brand">
                     <strong>Next steps:</strong> Update your DNS records and wait for propagation.
                     This can take up to 24 hours.
                   </p>
@@ -160,8 +160,8 @@ export default function CustomDomain() {
               )}
 
               {domain.status === 'error' && (
-                <div className="mt-4 p-3 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded">
-                  <p className="text-sm text-red-800 dark:text-red-200">
+                <div className="mt-4 p-3 bg-red-950 border border-red-800 rounded">
+                  <p className="text-sm text-red-200">
                     <strong>Configuration error:</strong> Please check your DNS records and try
                     again.
                   </p>
@@ -172,9 +172,9 @@ export default function CustomDomain() {
         </div>
 
         {/* Instructions */}
-        <div className="mt-6 p-4 bg-surface-0 bg-surface-2 rounded">
+        <div className="mt-6 p-4 bg-surface-2 rounded">
           <h4 className="font-medium mb-2">Setup Instructions:</h4>
-          <ol className="text-sm text-text-secondary dark:text-text-muted space-y-1 list-decimal list-inside">
+          <ol className="text-sm text-text-secondary space-y-1 list-decimal list-inside">
             <li>Add your domain using the form above</li>
             <li>Configure the DNS records in your domain provider</li>
             <li>Wait for DNS propagation (up to 24 hours)</li>

--- a/apps/web/src/components/billing/SubscriptionStatus.tsx
+++ b/apps/web/src/components/billing/SubscriptionStatus.tsx
@@ -11,10 +11,10 @@ export function SubscriptionStatus({ plan, status, cancelAtPeriodEnd }: Subscrip
 
   const statusColor =
     status === 'active'
-      ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+      ? 'bg-green-900/30 text-green-400'
       : status === 'past_due'
-        ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
-        : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+        ? 'bg-yellow-900/30 text-yellow-400'
+        : 'bg-red-900/30 text-red-400';
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/web/src/components/billing/UpgradePrompt.tsx
+++ b/apps/web/src/components/billing/UpgradePrompt.tsx
@@ -9,14 +9,12 @@ interface UpgradePromptProps {
 
 export function UpgradePrompt({ resource }: UpgradePromptProps) {
   return (
-    <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-900/20">
+    <div className="rounded-lg border border-yellow-800 bg-yellow-900/20 p-4">
       <div className="flex items-start gap-3">
-        <Zap className="mt-0.5 h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+        <Zap className="mt-0.5 h-5 w-5 text-yellow-400" />
         <div>
-          <h4 className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-            {resource} limit reached
-          </h4>
-          <p className="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
+          <h4 className="text-sm font-medium text-yellow-200">{resource} limit reached</h4>
+          <p className="mt-1 text-sm text-yellow-300">
             Upgrade to Pro for more capacity and advanced features.
           </p>
           <Link

--- a/apps/web/src/components/billing/UsageChart.tsx
+++ b/apps/web/src/components/billing/UsageChart.tsx
@@ -22,7 +22,7 @@ export function UsageChart({ label, current, limit }: UsageChartProps) {
       <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
         <div
           className={`h-full rounded-full transition-all ${
-            isNearLimit ? 'bg-yellow-500 dark:bg-yellow-400' : 'bg-primary'
+            isNearLimit ? 'bg-yellow-400' : 'bg-primary'
           }`}
           style={{ width: isUnlimited ? '0%' : `${percentage}%` }}
         />

--- a/apps/web/src/components/dashboard/PRStatus.tsx
+++ b/apps/web/src/components/dashboard/PRStatus.tsx
@@ -15,9 +15,9 @@ interface PRStatusProps {
 }
 
 const stateColors = {
-  open: 'text-green-600 bg-green-50 dark:bg-green-950',
-  closed: 'text-red-600 bg-red-50 dark:bg-red-950',
-  merged: 'text-purple-600 bg-purple-50 dark:bg-purple-950',
+  open: 'text-green-600 bg-green-950',
+  closed: 'text-red-600 bg-red-950',
+  merged: 'text-purple-600 bg-purple-950',
 };
 
 export default function PRStatus({ prs }: PRStatusProps) {

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -9,8 +9,7 @@ const alertVariants = cva(
     variants: {
       variant: {
         default: 'bg-background text-foreground',
-        destructive:
-          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+        destructive: 'border-destructive text-destructive [&>svg]:text-destructive',
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/wireframe/FigmaExportDialog.tsx
+++ b/apps/web/src/components/wireframe/FigmaExportDialog.tsx
@@ -197,13 +197,11 @@ export function FigmaExportDialog({ wireframe, onClose }: FigmaExportDialogProps
 
           {/* Success Result */}
           {exportResult && (
-            <Card className="border-green-200 dark:border-green-800">
+            <Card className="border-green-800">
               <CardHeader className="pb-3">
                 <div className="flex items-center gap-2">
                   <CheckCircle className="h-5 w-5 text-green-600" />
-                  <CardTitle className="text-base text-green-700 dark:text-green-400">
-                    Export Successful
-                  </CardTitle>
+                  <CardTitle className="text-base text-green-400">Export Successful</CardTitle>
                 </div>
               </CardHeader>
               <CardContent className="space-y-4">

--- a/apps/web/src/components/wireframe/WireframePreview.tsx
+++ b/apps/web/src/components/wireframe/WireframePreview.tsx
@@ -187,10 +187,10 @@ export function WireframePreview({ wireframe }: WireframePreviewProps) {
       {/* Preview Area */}
       <div className="flex-1 flex gap-4">
         {/* SVG Preview */}
-        <div className="flex-1 bg-surface-1 dark:bg-surface-0 rounded-lg border border-border overflow-auto">
+        <div className="flex-1 bg-surface-0 rounded-lg border border-border overflow-auto">
           <div className="p-8 flex justify-center items-center min-h-full">
             <div
-              className="bg-surface-1 dark:bg-surface-0 border-2 border-border rounded-lg shadow-lg"
+              className="bg-surface-0 border-2 border-border rounded-lg shadow-lg"
               style={{
                 transform: `scale(${scale})`,
                 transformOrigin: 'center',


### PR DESCRIPTION
## Summary
- Remove all `dark:` variant prefixes across 12 components (unnecessary in dark-only app)
- Remove duplicate `bg-surface-*` classes in AnalyticsDashboard, CustomDomain, and others
- Remove redundant `bg-brand/10` alongside `bg-brand-muted`
- Consolidate light/dark color pairs to dark-only values (e.g., `bg-yellow-50 dark:bg-yellow-900/20` → `bg-yellow-900/20`)

## Files changed
- AnalyticsDashboard.tsx, CustomDomain.tsx
- WireframePreview.tsx, FigmaExportDialog.tsx
- UpgradePrompt.tsx, UsageChart.tsx, SubscriptionStatus.tsx
- PRStatus.tsx, alert.tsx
- page.tsx (landing), generate-client.tsx, docs/page.tsx

## Test plan
- [ ] CI passes (lint, type-check, build, tests)
- [ ] Visual verification of affected components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated theme and color schemes across dashboard, billing, and documentation pages.
  * Simplified dark mode styling and gradient handling throughout the application UI.
  * Refined component styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->