### PR TITLE
test: Stripe webhook tests and community docs

### DIFF
--- a/apps/web/src/__tests__/lib/features/flags.test.ts
+++ b/apps/web/src/__tests__/lib/features/flags.test.ts
@@ -66,6 +66,8 @@ describe('Feature Flags', () => {
 
   describe('getFeatureFlag', () => {
     it('should return default value when no env var set', () => {
+      delete process.env.NEXT_PUBLIC_ENABLE_GOOGLE_SSO;
+      delete process.env.NEXT_PUBLIC_ENABLE_STRIPE_BILLING;
       expect(getFeatureFlag('ENABLE_GOOGLE_SSO')).toBe(true);
       expect(getFeatureFlag('ENABLE_STRIPE_BILLING')).toBe(false);
     });
@@ -88,6 +90,8 @@ describe('Feature Flags', () => {
 
   describe('getAllFeatureFlags', () => {
     it('should return all flags with defaults', () => {
+      delete process.env.NEXT_PUBLIC_ENABLE_STRIPE_BILLING;
+      delete process.env.NEXT_PUBLIC_ENABLE_USAGE_LIMITS;
       const flags = getAllFeatureFlags();
       expect(Object.keys(flags)).toHaveLength(17);
       expect(flags.ENABLE_GOOGLE_SSO).toBe(true);


### PR DESCRIPTION
## Summary

- Add 19 Stripe webhook handler tests covering all event types (checkout, subscription update/delete)
- Test `getPlanFromPriceId` for pro, team, unknown, and missing price scenarios
- Test event deduplication via `isEventProcessed` and `markEventProcessed`
- Fix feature flags test env isolation (clear billing env vars before testing defaults)
- Update README with community section, docs links, and Discussions badge
- Update CHANGELOG with v0.4.0 additions

## Test plan

- [x] `npx jest --no-coverage --forceExit` — 159 tests pass (16 suites)
- [x] Webhook tests cover: `verifyWebhookSignature`, `isEventProcessed`, `handleCheckoutCompleted`, `handleSubscriptionUpdated`, `handleSubscriptionDeleted`, `processWebhookEvent`
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)