### PR TITLE
fix: Replace hardcoded GA placeholder with env variable

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -50,3 +50,6 @@ STRIPE_PRO_PRICE_ID=price_xxxxx
 STRIPE_TEAM_PRICE_ID=price_xxxxx
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxxxx
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Google Analytics (leave empty to disable)
+NEXT_PUBLIC_GA_TRACKING_ID=


### PR DESCRIPTION
## Summary
- Replace 4 hardcoded `G-XXXXXXXXXX` placeholders in `AnalyticsProvider.tsx` with `NEXT_PUBLIC_GA_TRACKING_ID` env var
- Guard: if no tracking ID configured, skip GA script injection entirely (return children only)
- Add `NEXT_PUBLIC_GA_TRACKING_ID=` to `.env.example`

## Test plan
- [x] `npm run build` passes
- [x] Zero `G-XXXXXXXXXX` in codebase
- [ ] Analytics disabled when env var is empty (no GA scripts injected)
- [ ] Analytics works when valid GA ID is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Google Analytics tracking is now optional and can be disabled by leaving the tracking ID empty in configuration.
  * Added analytics tracking for project creation events.
  * Added analytics tracking for error events with contextual information.

* **Chores**
  * Updated environment configuration template to support Google Analytics setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->