### PR TITLE
feat: v0.5.0 Production-ready Supabase + messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] — 2026-02-24
+
+### Changed
+
+- **Production Supabase**: Linked project nfwmwdzbnvsyziyeubqb, config.toml with production URLs
+- **Auth redirect URLs**: OAuth callback URIs for Google/GitHub point to production Supabase
+- **Email URL fix**: auth-emails.ts uses NEXT_PUBLIC_BASE_URL (deploy workflow) instead of undefined NEXT_PUBLIC_APP_URL
+- **Messaging**: Updated all zero-cost references to generous free tier / low cost positioning
+
+### Notes
+
+- OAuth providers (Google, GitHub) require manual setup in Supabase Dashboard + provider consoles
+- Email delivery requires Resend SMTP configuration in Supabase Dashboard
+- Stripe remains in test mode for beta period
+
+---
+
 ## [0.4.0] — 2026-02-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # siza
 
-Zero-cost web application for AI-driven UI generation. Turborepo monorepo.
+AI-driven UI generation with a generous free tier. Turborepo monorepo.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Every AI code tool generates beautiful frontends. Then you spend days wiring aut
 | Full-stack (UI + backend + deploy) | Frontend-only generator |
 | MCP-native (composable AI tools) | Monolithic AI black box |
 | Privacy-first (BYOK, zero telemetry) | Data-harvesting freemium |
-| Zero-cost by default | Free trial with paywall |
+| Generous free tier, low cost to scale | Free trial with paywall |
 
 ## Features
 
@@ -118,7 +118,7 @@ npm run type-check      # TypeScript
 
 ## Pricing
 
-Free for individuals, paid for scale and convenience.
+Generous free tier, paid for scale and convenience.
 
 | Tier | Price | Generations | Projects |
 |------|-------|-------------|----------|

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/docs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/src/app/(marketing)/about/page.tsx
+++ b/apps/web/src/app/(marketing)/about/page.tsx
@@ -53,9 +53,9 @@ const principles = [
   },
   {
     icon: DollarSign,
-    title: 'True zero-cost, not freemium bait',
+    title: 'Low cost, not freemium bait',
     description:
-      'Cloudflare Workers, Supabase, Gemini free tiers support ~50K users at $0/month. No VC burn rate, no surprise bills. Sustainable from day one.',
+      'Generous free tier with high usage limits. Cloudflare Workers, Supabase, and scalable infrastructure keep costs low. No surprise bills, sustainable from day one.',
   },
   {
     icon: Unlock,

--- a/apps/web/src/app/(marketing)/landing/page.tsx
+++ b/apps/web/src/app/(marketing)/landing/page.tsx
@@ -287,10 +287,10 @@ export default function LandingPage() {
           <h2 className="text-3xl font-bold tracking-tight mb-3">
             Built in the open.
             <br />
-            <span className="text-muted-foreground">Zero-cost forever.</span>
+            <span className="text-muted-foreground">Free to start, low cost to scale.</span>
           </h2>
           <p className="text-muted-foreground mb-8 max-w-md mx-auto">
-            Siza runs entirely on free-tier infrastructure. No surprises, no paywalls.
+            Generous free tier with high usage limits. No surprises, no paywalls.
           </p>
           <div className="flex justify-center gap-4">
             <Button variant="outline" asChild>

--- a/apps/web/src/app/(marketing)/pricing/pricing-client.tsx
+++ b/apps/web/src/app/(marketing)/pricing/pricing-client.tsx
@@ -42,10 +42,10 @@ export function PricingPageClient() {
             <Code2 className="h-8 w-8 text-primary" />
             <span className="text-2xl font-bold">Siza</span>
           </Link>
-          <h1 className="mt-8 text-4xl font-bold">Free for individuals, paid for scale</h1>
+          <h1 className="mt-8 text-4xl font-bold">Generous free tier, paid for scale</h1>
           <p className="mt-4 text-lg text-muted-foreground">
-            Start free forever. BYOK unlocks unlimited generations at no cost. Upgrade when you need
-            team features.
+            Start free with high usage limits. BYOK unlocks unlimited generations. Upgrade when you
+            need team features.
           </p>
         </div>
 

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -4,6 +4,6 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
-    version: process.env.npm_package_version || '0.4.0',
+    version: process.env.npm_package_version || '0.5.0',
   });
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -26,7 +26,7 @@ const jetbrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: 'Siza - AI-Driven UI Generation',
   description:
-    'Generate production-ready UI components with AI. Zero-cost platform for developers.',
+    'Generate production-ready UI components with AI. Generous free tier for developers.',
   keywords: ['UI generation', 'AI', 'React', 'Next.js', 'Vue', 'Components'],
   authors: [{ name: 'Siza Team' }],
   icons: {

--- a/apps/web/src/lib/email/auth-emails.ts
+++ b/apps/web/src/lib/email/auth-emails.ts
@@ -3,7 +3,7 @@ import { sendEmail } from './service';
 import { Welcome } from '@/emails/templates/Welcome';
 import { getFeatureFlag } from '@/lib/features/flags';
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+const APP_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
 
 export async function sendWelcomeEmail(to: string) {
   if (!getFeatureFlag('ENABLE_RESEND_EMAILS')) return;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "siza-webapp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "license": "MIT",
-  "description": "Zero-cost web application for AI-driven UI generation",
+  "description": "AI-driven UI generation with a generous free tier",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -3,7 +3,7 @@
 # Created: 2026-02-15
 
 # Project settings
-project_id = "your-project-ref"
+project_id = "nfwmwdzbnvsyziyeubqb"
 
 [api]
 enabled = true
@@ -48,8 +48,8 @@ enabled = true
 
 [auth]
 enabled = true
-site_url = "http://localhost:3000"
-additional_redirect_urls = ["http://localhost:3000/**"]
+site_url = "https://siza-web.uiforge.workers.dev"
+additional_redirect_urls = ["https://siza-web.uiforge.workers.dev/**", "http://localhost:3000/**"]
 jwt_expiry = 3600
 enable_refresh_token_rotation = true
 refresh_token_reuse_interval = 10
@@ -75,13 +75,13 @@ enable_confirmations = true
 enabled = true
 client_id = "env(GOOGLE_CLIENT_ID)"
 secret = "env(GOOGLE_CLIENT_SECRET)"
-redirect_uri = "http://localhost:54321/auth/v1/callback"
+redirect_uri = "https://nfwmwdzbnvsyziyeubqb.supabase.co/auth/v1/callback"
 
 [auth.external.github]
 enabled = true
 client_id = "env(GITHUB_CLIENT_ID)"
 secret = "env(GITHUB_CLIENT_SECRET)"
-redirect_uri = "http://localhost:54321/auth/v1/callback"
+redirect_uri = "https://nfwmwdzbnvsyziyeubqb.supabase.co/auth/v1/callback"
 
 # [edge_functions]
 # enabled = false


### PR DESCRIPTION
## Summary

- **Production Supabase wired**: `config.toml` now points to `nfwmwdzbnvsyziyeubqb` with production site_url, OAuth redirect URIs for Google/GitHub
- **Email URL bug fixed**: `auth-emails.ts` used `NEXT_PUBLIC_APP_URL` (never set) — changed to `NEXT_PUBLIC_BASE_URL` (set in deploy workflow)
- **Messaging updated**: All "zero-cost" references replaced with "generous free tier / low cost to scale" positioning
- **Version bumped to 0.5.0**: root, web, docs packages + health endpoint fallback

## Manual steps required after merge

1. **Supabase auth**: `supabase login && supabase link --project-ref nfwmwdzbnvsyziyeubqb && supabase db push`
2. **Supabase Dashboard**: Set Site URL + Redirect URLs in Auth settings
3. **Google OAuth**: Create OAuth 2.0 client → copy credentials to Supabase
4. **GitHub OAuth**: Create OAuth App → copy credentials to Supabase
5. **Email (Resend)**: Configure SMTP in Supabase Dashboard Auth settings

## Test plan

- [ ] Verify `supabase db push` applies all 12 migrations successfully
- [ ] Verify health endpoint returns `{"version":"0.5.0"}`
- [ ] Verify email sign-up sends verification email to correct URL
- [ ] Verify Google/GitHub OAuth flows work end-to-end
- [ ] Verify pricing page shows "Generous free tier" messaging
- [ ] Verify about page shows "Low cost, not freemium bait"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Version**
  * Updated to version 0.5.0

* **Marketing & Messaging**
  * Refined pricing and value proposition messaging across the platform
  * Updated core messaging to emphasize "generous free tier" with high usage limits instead of zero-cost model
  * Refreshed copy on landing page, about page, and pricing page to reflect updated positioning
  * Updated product description to highlight free tier and scalable infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->