### PR TITLE
test: Unskip encryption and auth tests, raise coverage thresholds

### DIFF
--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -36,10 +36,10 @@ const customJestConfig = {
   ],
   coverageThreshold: {
     global: {
-      branches: 30,
-      functions: 30,
-      lines: 40,
-      statements: 40,
+      branches: 60,
+      functions: 65,
+      lines: 75,
+      statements: 75,
     },
   },
 };

--- a/apps/web/src/__tests__/components/auth/SignInPage.test.tsx
+++ b/apps/web/src/__tests__/components/auth/SignInPage.test.tsx
@@ -1,197 +1,124 @@
 /**
  * Sign In Page Component Tests
- * Tests for the user authentication interface
  */
 
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SignInPage from '@/app/(auth)/signin/page';
-import { TEST_CONFIG } from '../../../../../../test-config';
 
-// Mock Next.js router
+const mockPush = jest.fn();
+const mockRefresh = jest.fn();
+const mockSignInWithPassword = jest.fn();
+const mockSignInWithGoogle = jest.fn();
+const mockSignInWithGitHub = jest.fn();
+
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-  }),
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), refresh: mockRefresh }),
   useSearchParams: () => new URLSearchParams(),
 }));
 
-// Mock Supabase auth
 jest.mock('@/lib/supabase/client', () => ({
-  signIn: jest.fn(),
-  signUp: jest.fn(),
+  createClient: () => ({ auth: { signInWithPassword: mockSignInWithPassword } }),
 }));
 
-// TODO: Enable when feature is implemented
-describe.skip('SignInPage', () => {
+jest.mock('@/lib/auth/oauth', () => ({
+  signInWithGoogle: (...args: any[]) => mockSignInWithGoogle(...args),
+  signInWithGitHub: (...args: any[]) => mockSignInWithGitHub(...args),
+}));
+
+jest.mock('@/components/auth/oauth-button', () => ({
+  OAuthButton: ({ provider, onClick, disabled }: any) => (
+    <button onClick={onClick} disabled={disabled}>
+      Continue with {provider === 'google' ? 'Google' : 'GitHub'}
+    </button>
+  ),
+}));
+
+describe('SignInPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSignInWithPassword.mockResolvedValue({ error: null });
+    mockSignInWithGoogle.mockResolvedValue({ error: null });
+    mockSignInWithGitHub.mockResolvedValue({ error: null });
   });
 
-  it('should render sign in form', () => {
-    const { getByLabelText, getByRole } = render(<SignInPage />);
-
-    expect(getByLabelText(/email/i)).toBeInTheDocument();
-    expect(getByLabelText(/password/i)).toBeInTheDocument();
-    expect(getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  it('should render sign in form with email and password', () => {
+    render(<SignInPage />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
   });
 
   it('should show sign up link', () => {
-    const { getByText } = render(<SignInPage />);
-
-    expect(getByText(/don't have an account/i)).toBeInTheDocument();
-    expect(getByText(/sign up/i)).toBeInTheDocument();
+    render(<SignInPage />);
+    expect(screen.getByText(/don't have an account/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sign up/i })).toHaveAttribute('href', '/signup');
   });
 
-  it('should validate email input', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignInPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const signInButton = getByRole('button', { name: /sign in/i });
-
-    // Try to submit with empty email
-    await userEvent.clear(emailInput);
-    await userEvent.click(signInButton);
-
-    expect(getByText(/email is required/i)).toBeInTheDocument();
+  it('should show forgot password link', () => {
+    render(<SignInPage />);
+    expect(screen.getByRole('link', { name: /forgot password/i })).toHaveAttribute('href', '/forgot-password');
   });
 
-  it('should validate password input', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignInPage />);
-
-    const passwordInput = getByLabelText(/password/i);
-    const signInButton = getByRole('button', { name: /sign in/i });
-
-    // Try to submit with empty password
-    await userEvent.clear(passwordInput);
-    await userEvent.click(signInButton);
-
-    expect(getByText(/password is required/i)).toBeInTheDocument();
+  it('should submit form with email and password', async () => {
+    const user = userEvent.setup();
+    render(<SignInPage />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => {
+      expect(mockSignInWithPassword).toHaveBeenCalledWith({
+        email: 'test@example.com', password: 'password123',
+      });
+    });
   });
 
-  it('should validate email format', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignInPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const signInButton = getByRole('button', { name: /sign in/i });
-
-    // Enter invalid email
-    await userEvent.type(emailInput, 'invalid-email');
-    await userEvent.click(signInButton);
-
-    expect(getByText(/please enter a valid email/i)).toBeInTheDocument();
+  it('should redirect to dashboard on success', async () => {
+    const user = userEvent.setup();
+    render(<SignInPage />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => { expect(mockPush).toHaveBeenCalledWith('/dashboard'); });
   });
 
-  it('should handle form submission with valid data', async () => {
-    const { signIn } = require('@/lib/supabase/client');
-    const { getByLabelText, getByRole } = render(<SignInPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const signInButton = getByRole('button', { name: /sign in/i });
-
-    // Fill form with valid data
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-
-    // Submit form
-    await userEvent.click(signInButton);
-
-    // Should call signIn function
-    expect(signIn).toHaveBeenCalledWith({
-      email: 'test@example.com',
-      password: TEST_CONFIG.PASSWORDS.USER,
+  it('should show error on sign in failure', async () => {
+    mockSignInWithPassword.mockResolvedValue({ error: { message: 'Invalid login credentials' } });
+    const user = userEvent.setup();
+    render(<SignInPage />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'wrong');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/invalid login credentials/i)).toBeInTheDocument();
     });
   });
 
   it('should show loading state during submission', async () => {
-    const { signIn } = require('@/lib/supabase/client');
-    signIn.mockImplementation(() => new Promise(() => {})); // Never resolves
-
-    const { getByLabelText, getByRole } = render(<SignInPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const signInButton = getByRole('button', { name: /sign in/i });
-
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.click(signInButton);
-
-    // Should show loading state
-    expect(signInButton).toBeDisabled();
-    expect(signInButton).toHaveTextContent(/signing in/i);
+    let resolveSignIn: (value: any) => void;
+    mockSignInWithPassword.mockReturnValue(new Promise((resolve) => { resolveSignIn = resolve; }));
+    const user = userEvent.setup();
+    render(<SignInPage />);
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+    expect(screen.getByText(/signing in/i)).toBeInTheDocument();
+    resolveSignIn!({ error: null });
   });
 
-  it('should handle sign in errors', async () => {
-    const { signIn } = require('@/lib/supabase/client');
-    signIn.mockRejectedValue(new Error('Invalid credentials'));
-
-    const { getByLabelText, getByRole, getByText } = render(<SignInPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const signInButton = getByRole('button', { name: /sign in/i });
-
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, 'wrongpassword');
-    await userEvent.click(signInButton);
-
-    // Should show error message
-    expect(getByText(/invalid credentials/i)).toBeInTheDocument();
+  it('should render OAuth buttons', () => {
+    render(<SignInPage />);
+    expect(screen.getByRole('button', { name: /continue with google/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue with github/i })).toBeInTheDocument();
   });
 
-  it('should navigate to sign up page', async () => {
-    const { useRouter } = require('next/navigation');
-    const mockPush = jest.fn();
-    useRouter.mockReturnValue({
-      push: mockPush,
-      replace: jest.fn(),
+  it('should handle Google OAuth error', async () => {
+    mockSignInWithGoogle.mockResolvedValue({ error: { message: 'Google auth failed' } });
+    const user = userEvent.setup();
+    render(<SignInPage />);
+    await user.click(screen.getByRole('button', { name: /continue with google/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/google auth failed/i)).toBeInTheDocument();
     });
-
-    const { getByText } = render(<SignInPage />);
-
-    const signUpLink = getByText(/sign up/i);
-    await userEvent.click(signUpLink);
-
-    expect(mockPush).toHaveBeenCalledWith('/signup');
-  });
-
-  it('should handle redirect after successful sign in', async () => {
-    const { signIn } = require('@/lib/supabase/client');
-    const { useRouter } = require('next/navigation');
-    const mockReplace = jest.fn();
-    useRouter.mockReturnValue({
-      push: jest.fn(),
-      replace: mockReplace,
-    });
-
-    signIn.mockResolvedValue({ user: { id: '123', email: 'test@example.com' } });
-
-    const { getByLabelText, getByRole } = render(<SignInPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const signInButton = getByRole('button', { name: /sign in/i });
-
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.click(signInButton);
-
-    // Should redirect to dashboard
-    expect(mockReplace).toHaveBeenCalledWith('/dashboard');
-  });
-
-  it('should remember me option', () => {
-    const { getByLabelText } = render(<SignInPage />);
-
-    expect(getByLabelText(/remember me/i)).toBeInTheDocument();
-  });
-
-  it('should show forgot password link', () => {
-    const { getByText } = render(<SignInPage />);
-
-    expect(getByText(/forgot password/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/__tests__/components/auth/SignUpPage.test.tsx
+++ b/apps/web/src/__tests__/components/auth/SignUpPage.test.tsx
@@ -1,247 +1,124 @@
 /**
  * Sign Up Page Component Tests
- * Tests for the user registration interface
  */
 
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SignUpPage from '@/app/(auth)/signup/page';
-import { TEST_CONFIG } from '../../../../../../test-config';
 
-// Mock Next.js router
+const mockSignUp = jest.fn();
+const mockSignInWithGoogle = jest.fn();
+const mockSignInWithGitHub = jest.fn();
+
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-  }),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
   useSearchParams: () => new URLSearchParams(),
 }));
 
-// Mock Supabase auth
 jest.mock('@/lib/supabase/client', () => ({
-  signUp: jest.fn(),
-  signIn: jest.fn(),
+  createClient: () => ({ auth: { signUp: mockSignUp } }),
 }));
 
-// TODO: Enable when feature is implemented
-describe.skip('SignUpPage', () => {
+jest.mock('@/lib/auth/oauth', () => ({
+  signInWithGoogle: (...args: any[]) => mockSignInWithGoogle(...args),
+  signInWithGitHub: (...args: any[]) => mockSignInWithGitHub(...args),
+}));
+
+jest.mock('@/components/auth/oauth-button', () => ({
+  OAuthButton: ({ provider, onClick, disabled }: any) => (
+    <button onClick={onClick} disabled={disabled}>
+      Continue with {provider === 'google' ? 'Google' : 'GitHub'}
+    </button>
+  ),
+}));
+
+describe('SignUpPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSignUp.mockResolvedValue({ error: null });
+    mockSignInWithGoogle.mockResolvedValue({ error: null });
+    mockSignInWithGitHub.mockResolvedValue({ error: null });
   });
 
   it('should render sign up form', () => {
-    const { getByLabelText, getByRole } = render(<SignUpPage />);
-
-    expect(getByLabelText(/email/i)).toBeInTheDocument();
-    expect(getByLabelText(/password/i)).toBeInTheDocument();
-    expect(getByLabelText(/confirm password/i)).toBeInTheDocument();
-    expect(getByRole('button', { name: /sign up/i })).toBeInTheDocument();
+    render(<SignUpPage />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
   });
 
   it('should show sign in link', () => {
-    const { getByText } = render(<SignUpPage />);
-
-    expect(getByText(/already have an account/i)).toBeInTheDocument();
-    expect(getByText(/sign in/i)).toBeInTheDocument();
+    render(<SignUpPage />);
+    expect(screen.getByText(/already have an account/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/signin');
   });
 
-  it('should validate email input', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignUpPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    // Try to submit with empty email
-    await userEvent.clear(emailInput);
-    await userEvent.click(signUpButton);
-
-    expect(getByText(/email is required/i)).toBeInTheDocument();
+  it('should show password requirements', () => {
+    render(<SignUpPage />);
+    expect(screen.getByText(/must be at least 6 characters/i)).toBeInTheDocument();
   });
 
-  it('should validate password input', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignUpPage />);
-
-    const passwordInput = getByLabelText(/password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    // Try to submit with empty password
-    await userEvent.clear(passwordInput);
-    await userEvent.click(signUpButton);
-
-    expect(getByText(/password is required/i)).toBeInTheDocument();
+  it('should submit form with email and password', async () => {
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+    await user.type(screen.getByLabelText(/email/i), 'new@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+    await waitFor(() => {
+      expect(mockSignUp).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'new@example.com', password: 'password123' })
+      );
+    });
   });
 
-  it('should validate password confirmation', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignUpPage />);
-
-    const passwordInput = getByLabelText(/password/i);
-    const confirmPasswordInput = getByLabelText(/confirm password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    // Enter different passwords
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.type(confirmPasswordInput, 'different456');
-    await userEvent.click(signUpButton);
-
-    expect(getByText(/passwords do not match/i)).toBeInTheDocument();
+  it('should show success message after sign up', async () => {
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+    await user.type(screen.getByLabelText(/email/i), 'new@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/check your email/i)).toBeInTheDocument();
+    });
   });
 
-  it('should validate email format', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignUpPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    // Enter invalid email
-    await userEvent.type(emailInput, 'invalid-email');
-    await userEvent.click(signUpButton);
-
-    expect(getByText(/please enter a valid email/i)).toBeInTheDocument();
-  });
-
-  it('should validate password strength', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignUpPage />);
-
-    const passwordInput = getByLabelText(/password/i);
-    const confirmPasswordInput = getByLabelText(/confirm password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    // Enter weak password
-    await userEvent.type(passwordInput, '123');
-    await userEvent.type(confirmPasswordInput, '123');
-    await userEvent.click(signUpButton);
-
-    expect(getByText(/password must be at least 8 characters/i)).toBeInTheDocument();
-  });
-
-  it('should handle form submission with valid data', async () => {
-    const { signUp } = require('@/lib/supabase/client');
-    const { getByLabelText, getByRole } = render(<SignUpPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const confirmPasswordInput = getByLabelText(/confirm password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    // Fill form with valid data
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.type(confirmPasswordInput, 'password123');
-
-    // Submit form
-    await userEvent.click(signUpButton);
-
-    // Should call signUp function
-    expect(signUp).toHaveBeenCalledWith({
-      email: 'test@example.com',
-      password: TEST_CONFIG.PASSWORDS.USER,
+  it('should show error on sign up failure', async () => {
+    mockSignUp.mockResolvedValue({ error: { message: 'User already registered' } });
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+    await user.type(screen.getByLabelText(/email/i), 'existing@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/user already registered/i)).toBeInTheDocument();
     });
   });
 
   it('should show loading state during submission', async () => {
-    const { signUp } = require('@/lib/supabase/client');
-    signUp.mockImplementation(() => new Promise(() => {})); // Never resolves
-
-    const { getByLabelText, getByRole } = render(<SignUpPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const confirmPasswordInput = getByLabelText(/confirm password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.type(confirmPasswordInput, 'password123');
-    await userEvent.click(signUpButton);
-
-    // Should show loading state
-    expect(signUpButton).toBeDisabled();
-    expect(signUpButton).toHaveTextContent(/signing up/i);
+    let resolveSignUp: (value: any) => void;
+    mockSignUp.mockReturnValue(new Promise((resolve) => { resolveSignUp = resolve; }));
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+    await user.type(screen.getByLabelText(/email/i), 'new@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+    expect(screen.getByText(/creating account/i)).toBeInTheDocument();
+    resolveSignUp!({ error: null });
   });
 
-  it('should handle sign up errors', async () => {
-    const { signUp } = require('@/lib/supabase/client');
-    signUp.mockRejectedValue(new Error('User already exists'));
-
-    const { getByLabelText, getByRole, getByText } = render(<SignUpPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const confirmPasswordInput = getByLabelText(/confirm password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.type(confirmPasswordInput, 'password123');
-    await userEvent.click(signUpButton);
-
-    // Should show error message
-    expect(getByText(/user already exists/i)).toBeInTheDocument();
+  it('should render OAuth buttons', () => {
+    render(<SignUpPage />);
+    expect(screen.getByRole('button', { name: /continue with google/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue with github/i })).toBeInTheDocument();
   });
 
-  it('should navigate to sign in page', async () => {
-    const { useRouter } = require('next/navigation');
-    const mockPush = jest.fn();
-    useRouter.mockReturnValue({
-      push: mockPush,
-      replace: jest.fn(),
+  it('should handle GitHub OAuth error', async () => {
+    mockSignInWithGitHub.mockResolvedValue({ error: { message: 'GitHub auth failed' } });
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+    await user.click(screen.getByRole('button', { name: /continue with github/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/github auth failed/i)).toBeInTheDocument();
     });
-
-    const { getByText } = render(<SignUpPage />);
-
-    const signInLink = getByText(/sign in/i);
-    await userEvent.click(signInLink);
-
-    expect(mockPush).toHaveBeenCalledWith('/signin');
-  });
-
-  it('should handle redirect after successful sign up', async () => {
-    const { signUp } = require('@/lib/supabase/client');
-    const { useRouter } = require('next/navigation');
-    const mockReplace = jest.fn();
-    useRouter.mockReturnValue({
-      push: jest.fn(),
-      replace: mockReplace,
-    });
-
-    signUp.mockResolvedValue({ user: { id: '123', email: 'test@example.com' } });
-
-    const { getByLabelText, getByRole } = render(<SignUpPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const confirmPasswordInput = getByLabelText(/confirm password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.type(confirmPasswordInput, 'password123');
-    await userEvent.click(signUpButton);
-
-    // Should redirect to dashboard
-    expect(mockReplace).toHaveBeenCalledWith('/dashboard');
-  });
-
-  it('should show terms and conditions checkbox', () => {
-    const { getByLabelText } = render(<SignUpPage />);
-
-    expect(getByLabelText(/i agree to the terms and conditions/i)).toBeInTheDocument();
-  });
-
-  it('should require terms acceptance', async () => {
-    const { getByLabelText, getByRole, getByText } = render(<SignUpPage />);
-
-    const emailInput = getByLabelText(/email/i);
-    const passwordInput = getByLabelText(/password/i);
-    const confirmPasswordInput = getByLabelText(/confirm password/i);
-    const signUpButton = getByRole('button', { name: /sign up/i });
-
-    // Fill form but don't accept terms
-    await userEvent.type(emailInput, 'test@example.com');
-    await userEvent.type(passwordInput, TEST_CONFIG.PASSWORDS.USER);
-    await userEvent.type(confirmPasswordInput, 'password123');
-    await userEvent.click(signUpButton);
-
-    expect(getByText(/you must accept the terms and conditions/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/__tests__/lib/encryption.test.ts
+++ b/apps/web/src/__tests__/lib/encryption.test.ts
@@ -66,8 +66,7 @@ jest.mock('crypto-js', () => {
   };
 });
 
-// TODO: Enable when feature is implemented
-describe.skip('Encryption Utilities', () => {
+describe('Encryption Utilities', () => {
   describe('API Key Encryption/Decryption', () => {
     it('should encrypt and decrypt API keys correctly', () => {
       const apiKey = TEST_CONFIG.API_KEYS.OPENAI;


### PR DESCRIPTION
## Summary
- Unskip `encryption.test.ts`: 26 BYOK security tests now active (AES-256, key validation, expiration)
- Rewrite `SignInPage.test.tsx`: 9 tests matching current Supabase auth UI (form rendering, OAuth, error states, loading)
- Rewrite `SignUpPage.test.tsx`: 9 tests matching current signup flow (Create account, success email verification)
- Raise Jest coverage thresholds from 30-40% to 60-75% (actual: stmts 81%, branch 74%, funcs 84%, lines 83%)
- **Total: 203 tests passing (was 159), 19 suites (was 16)**

## Test plan
- [x] `npx jest --coverage` passes with raised thresholds
- [x] All 19 passing suites verified
- [x] `npm run build` passes