### PR TITLE
Release v0.5.0: Production hardening and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] — 2026-02-25
+
+### Added
+
+- **GitHub Releases**: v0.3.0 and v0.4.0 releases published with full notes
+- **Encryption tests**: 26 BYOK security tests unskipped and passing (AES-256, key validation, expiration)
+- **Auth page tests**: 18 new tests for SignIn/SignUp pages matching current Supabase auth UI
+- **Google Analytics env var**: `NEXT_PUBLIC_GA_TRACKING_ID` in `.env.example`
+
+### Changed
+
+- **Coverage thresholds raised**: branches 30→60%, functions 30→65%, lines 40→75%, statements 40→75%
+- **Actual coverage**: statements 81%, branches 74%, functions 84%, lines 83%
+- **Test count**: 203 tests passing (was 159), 19 suites (was 16)
+
+### Fixed
+
+- **Analytics provider**: Replace 4 hardcoded `G-XXXXXXXXXX` placeholders with `NEXT_PUBLIC_GA_TRACKING_ID` env var
+- **Analytics guard**: Skip GA script injection when tracking ID is not configured (no dead code in production)
+
+### Removed
+
+- 3 stale remote branches: `fix/stripe-bugs`, `fix/supabase-migrations`, `chore/docs-cleanup`
+- Issue #8 (Label Templates) closed — all labels already created
+
+---
+
 ## [0.4.0] — 2026-02-25
 
 ### Added

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/docs",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "license": "MIT",
   "description": "Zero-cost web application for AI-driven UI generation",


### PR DESCRIPTION
## Summary
v0.5.0 — Production Hardening & Cleanup

### Changes
- **Analytics fix**: Replace 4 hardcoded `G-XXXXXXXXXX` with `NEXT_PUBLIC_GA_TRACKING_ID` env var, guard when unset
- **Test quality**: 44 new tests enabled (encryption BYOK, SignIn, SignUp), 203 total (was 159)
- **Coverage raised**: thresholds from 30-40% to 60-75% (actual: 81%/74%/84%/83%)
- **Repo cleanup**: 3 stale branches deleted, issue #8 closed, GitHub Releases for v0.3.0 and v0.4.0

### Deferred
- `SUPABASE_SERVICE_ROLE_KEY` not in Cloudflare secrets — blocks Stripe E2E testing
- API route tests (projects, components) need Zod null coercion + rate-limit mock fixes
- 13 test suites still skipped (BYOK storage, generators, AI keys manager, hooks)

## Test plan
- [x] All 203 tests pass with raised coverage thresholds
- [x] `npm run build` passes
- [x] Zero `G-XXXXXXXXXX` in codebase
- [x] 0 open PRs across all repos (before this PR)