### PR TITLE
test: Add landing page E2E tests

### DIFF
--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -7,7 +7,7 @@ test.describe('Authentication', () => {
 
   test('should display landing page', async ({ page }) => {
     await expect(page.locator('text=Siza')).toBeVisible();
-    await expect(page.locator('text=Generate Production-Ready')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
   });
 
   test('should navigate to sign in page', async ({ page }) => {

--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Landing Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('should render navigation with logo and links', async ({ page }) => {
+    await expect(page.getByRole('link', { name: /siza/i }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: /sign in/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /get started/i }).first()).toBeVisible();
+  });
+
+  test('should render hero section with headline and CTAs', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(page.getByText(/an ecosystem that enables/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: /get started free/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /view on github/i })).toBeVisible();
+  });
+
+  test('should render stats bar with counters', async ({ page }) => {
+    await expect(page.getByText(/ai providers/i)).toBeVisible();
+    await expect(page.getByText(/ui components/i)).toBeVisible();
+    await expect(page.getByText(/core repositories/i)).toBeVisible();
+  });
+
+  test('should render capabilities section', async ({ page }) => {
+    await expect(page.getByText(/what makes it different/i)).toBeVisible();
+    await expect(page.getByText(/component architecture/i)).toBeVisible();
+    await expect(page.getByText(/ai provider gateway/i)).toBeVisible();
+    await expect(page.getByText(/edge-first performance/i)).toBeVisible();
+  });
+
+  test('should render code showcase section', async ({ page }) => {
+    await expect(page.getByText(/one gateway/i)).toBeVisible();
+    await expect(page.getByText(/gateway\.config\.ts/i)).toBeVisible();
+  });
+
+  test('should render ecosystem section', async ({ page }) => {
+    await expect(page.getByText(/the forge space ecosystem/i)).toBeVisible();
+    await expect(page.getByText(/ui-mcp/i)).toBeVisible();
+    await expect(page.getByText(/mcp-gateway/i)).toBeVisible();
+  });
+
+  test('should render footer with links', async ({ page }) => {
+    const footer = page.locator('footer');
+    await expect(footer).toBeVisible();
+    await expect(footer.getByText(/mit license/i)).toBeVisible();
+  });
+
+  test('should navigate to sign in from nav', async ({ page }) => {
+    await page.getByRole('link', { name: /sign in/i }).click();
+    await expect(page).toHaveURL('/signin');
+  });
+
+  test('should navigate to sign up from Get Started CTA', async ({ page }) => {
+    await page.getByRole('link', { name: /get started free/i }).click();
+    await expect(page).toHaveURL('/signup');
+  });
+
+  test('should apply nav blur on scroll', async ({ page }) => {
+    const nav = page.locator('nav').first();
+    await page.evaluate(() => window.scrollTo(0, 200));
+    await expect(nav.locator('..')).toHaveCSS('backdrop-filter', /blur/);
+  });
+
+  test('should render responsive mobile layout', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(page.getByRole('link', { name: /get started free/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12 E2E tests for the rebuilt landing page covering all major sections
- Fix outdated auth spec assertion (removed "Generate Production-Ready" text)

## Test coverage
- Nav: logo, links, sign in, get started
- Hero: headline, CTAs, GitHub link
- Stats bar: AI providers, UI components, core repos
- Capabilities: section title, card content
- Code showcase: gateway config display
- Ecosystem: Forge Space repos
- Footer: links and license
- Navigation: sign in, sign up redirects
- Scroll behavior: nav blur on scroll
- Responsive: mobile layout at 375px

## Test plan
- [x] `npx prettier --check` passes
- [x] `npx eslint` passes
- [ ] CI E2E job runs landing.spec.ts

Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication test assertions with improved element targeting.
  * Added comprehensive end-to-end test coverage for the landing page, including navigation, hero section, statistics, capabilities, code showcase, ecosystem, footer, and mobile responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->