### PR TITLE
fix: Remove 3072-dim HNSW indexes from ML migration

### DIFF
--- a/supabase/migrations/20260226000001_ml_feedback_store.sql
+++ b/supabase/migrations/20260226000001_ml_feedback_store.sql
@@ -125,24 +125,9 @@ create policy "Service role manages training runs"
 create index ml_training_runs_adapter_idx on public.ml_training_runs (adapter);
 create index ml_training_runs_status_idx on public.ml_training_runs (status);
 
--- ============================================================
--- 4. HNSW indexes on existing vector columns (production only)
--- ============================================================
-
-create index if not exists generations_embedding_hnsw_idx
-  on public.generations
-  using hnsw (prompt_embedding vector_cosine_ops)
-  with (m = 16, ef_construction = 64);
-
-create index if not exists components_embedding_hnsw_idx
-  on public.components
-  using hnsw (embedding vector_cosine_ops)
-  with (m = 16, ef_construction = 64);
-
-create index if not exists patterns_embedding_hnsw_idx
-  on public.component_patterns
-  using hnsw (embedding vector_cosine_ops)
-  with (m = 16, ef_construction = 64);
+-- Note: HNSW indexes on existing 3072-dim columns (generations, components,
+-- component_patterns) omitted — pgvector HNSW limit is 2000 dimensions.
+-- Use IVFFlat or reduce dimensions before indexing.
 
 -- ============================================================
 -- 5. Similarity search on ml_embeddings


### PR DESCRIPTION
## Summary
- Remove HNSW indexes on 3072-dim vector columns (pgvector limit is 2000 dims)
- Affects: `generations.prompt_embedding`, `components.embedding`, `component_patterns.embedding`
- ML tables and 1536-dim HNSW index on `ml_embeddings` are unaffected

Migration already applied to production with `supabase migration repair --status applied`.