### PR TITLE
feat: Add generation quota gating UI

### DIFF
--- a/apps/web/src/lib/api/generation.ts
+++ b/apps/web/src/lib/api/generation.ts
@@ -45,7 +45,13 @@ export async function* streamGeneration(
 
   if (!response.ok) {
     const errorData = await response.json();
-    throw new Error(errorData.error?.message || 'Generation failed');
+    const message =
+      typeof errorData.error === 'string'
+        ? errorData.error
+        : errorData.error?.message || 'Generation failed';
+    const err = new Error(message);
+    if (errorData.quota) (err as any).quota = errorData.quota;
+    throw err;
   }
 
   if (!response.body) {


### PR DESCRIPTION
## Summary
- **UpgradePrompt** shown proactively when quota exceeded (before submit) and on 429 error response
- **Usage counter** below API key status: "X / Y generations this month" with yellow "Nearing limit" at 80%
- **Generate button disabled** when quota exhausted
- **Error parsing fix** in `generation.ts`: API returns `{ error: string }` but client expected `{ error: { message } }` — quota errors were falling through to generic "Generation failed"
- **2 new tests** for quota exceeded and rate limit error handling

### Files Changed
- `apps/web/src/components/generator/GeneratorForm.tsx` — quota UI integration
- `apps/web/src/lib/api/generation.ts` — fix error parsing for string errors + preserve quota metadata
- `apps/web/src/__tests__/hooks/use-generation.test.ts` — add quota handling tests

## Test plan
- [ ] CI passes (lint, type-check, build, unit tests)
- [ ] Navigate to /generate with quota at limit -> UpgradePrompt shown, button disabled
- [ ] Generate button enabled when under quota
- [ ] 429 error shows UpgradePrompt instead of generic error
- [ ] Quota counter visible when usage limits enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)