### PR TITLE
feat: Add lightweight server-side Sentry error reporting

### DIFF
--- a/apps/web/src/app/api/components/route.ts
+++ b/apps/web/src/app/api/components/route.ts
@@ -10,6 +10,7 @@ import { verifySession } from '@/lib/api/auth';
 import { checkRateLimit, setRateLimitHeaders } from '@/lib/api/rate-limit';
 import { successResponse, createdResponse, errorResponse } from '@/lib/api/response';
 import { UnauthorizedError, ForbiddenError, ValidationError } from '@/lib/api/errors';
+import { captureServerError } from '@/lib/sentry/server';
 import { createComponentSchema, componentQuerySchema } from '@/lib/api/validation/components';
 import {
   uploadToStorage,
@@ -85,6 +86,7 @@ export async function GET(request: NextRequest) {
     }
 
     console.error('GET /api/components error:', error);
+    captureServerError(error, { route: '/api/components' });
     return errorResponse('Internal server error', 500);
   }
 }
@@ -247,6 +249,7 @@ export async function POST(request: NextRequest) {
     }
 
     console.error('POST /api/components error:', error);
+    captureServerError(error, { route: '/api/components' });
     return errorResponse('Internal server error', 500);
   }
 }

--- a/apps/web/src/lib/api/middleware.ts
+++ b/apps/web/src/lib/api/middleware.ts
@@ -8,6 +8,7 @@ import { checkRateLimit } from './rate-limit';
 import { verifySession } from './auth';
 import { ValidationError, type APIError } from './errors';
 import { errorResponse, apiErrorResponse } from './response';
+import { captureServerError } from '@/lib/sentry/server';
 import { type ZodSchema } from 'zod';
 
 type RouteHandler = (request: NextRequest, context?: any) => Promise<NextResponse>;
@@ -25,6 +26,7 @@ export function withAuth(handler: RouteHandler): RouteHandler {
         return apiErrorResponse(error as APIError);
       }
       console.error('Auth middleware error:', error);
+      captureServerError(error, { route: request.nextUrl.pathname });
       return errorResponse('Authentication failed', 401);
     }
   };
@@ -65,6 +67,7 @@ export function withRateLimit(
         return apiErrorResponse(error as APIError);
       }
       console.error('Rate limit middleware error:', error);
+      captureServerError(error, { route: request.nextUrl.pathname });
       return errorResponse('Rate limit check failed', 500);
     }
   };
@@ -94,6 +97,7 @@ export function withValidation<T>(
         return apiErrorResponse(error as APIError);
       }
       console.error('Validation middleware error:', error);
+      captureServerError(error, { route: request.nextUrl.pathname });
       return errorResponse('Validation failed', 400);
     }
   };
@@ -111,6 +115,7 @@ export function withErrorHandling(handler: RouteHandler): RouteHandler {
         return apiErrorResponse(error as APIError);
       }
       console.error('Route handler error:', error);
+      captureServerError(error, { route: request.nextUrl.pathname });
       return errorResponse('An unexpected error occurred', 500);
     }
   };

--- a/apps/web/src/lib/sentry/server.ts
+++ b/apps/web/src/lib/sentry/server.ts
@@ -1,0 +1,97 @@
+/**
+ * Lightweight server-side Sentry error reporting for Cloudflare Workers.
+ * Uses the Sentry Envelope API directly — zero additional dependencies.
+ * Bundle impact: ~0 KiB (no SDK added).
+ */
+
+interface SentryContext {
+  route?: string;
+  userId?: string;
+  extra?: Record<string, unknown>;
+}
+
+interface ParsedDSN {
+  publicKey: string;
+  projectId: string;
+  host: string;
+}
+
+function parseDSN(dsn: string): ParsedDSN | null {
+  try {
+    const url = new URL(dsn);
+    const publicKey = url.username;
+    const projectId = url.pathname.replace('/', '');
+    const host = url.hostname;
+    return { publicKey, projectId, host };
+  } catch {
+    return null;
+  }
+}
+
+function buildEnvelope(error: Error, dsn: ParsedDSN, context: SentryContext): string {
+  const eventId = crypto.randomUUID().replace(/-/g, '');
+  const timestamp = Date.now() / 1000;
+
+  const header = JSON.stringify({
+    event_id: eventId,
+    sent_at: new Date().toISOString(),
+    dsn: `https://${dsn.publicKey}@${dsn.host}/${dsn.projectId}`,
+  });
+
+  const itemHeader = JSON.stringify({ type: 'event' });
+
+  const payload = JSON.stringify({
+    event_id: eventId,
+    timestamp,
+    platform: 'javascript',
+    level: 'error',
+    server_name: 'siza-web-worker',
+    environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || 'production',
+    release: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+    exception: {
+      values: [
+        {
+          type: error.name,
+          value: error.message,
+          stacktrace: error.stack
+            ? {
+                frames: error.stack
+                  .split('\n')
+                  .slice(1, 10)
+                  .map((line: string) => ({ filename: line.trim() })),
+              }
+            : undefined,
+        },
+      ],
+    },
+    tags: {
+      ...(context.route && { route: context.route }),
+      runtime: 'cloudflare-workers',
+    },
+    user: context.userId ? { id: context.userId } : undefined,
+    extra: context.extra,
+  });
+
+  return `${header}\n${itemHeader}\n${payload}`;
+}
+
+export function captureServerError(error: unknown, context: SentryContext = {}): void {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn) return;
+
+  const parsed = parseDSN(dsn);
+  if (!parsed) return;
+
+  const err = error instanceof Error ? error : new Error(String(error));
+
+  const envelope = buildEnvelope(err, parsed, context);
+  const url = `https://${parsed.host}/api/${parsed.projectId}/envelope/`;
+
+  fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-sentry-envelope' },
+    body: envelope,
+  }).catch(() => {
+    // Fire-and-forget: never block request on Sentry failure
+  });
+}


### PR DESCRIPTION
## Summary
- **Sentry Envelope API** (`lib/sentry/server.ts`): ~100 lines, zero dependencies, zero bundle impact
- **API middleware integration**: All 4 error handlers (`withAuth`, `withRateLimit`, `withValidation`, `withErrorHandling`) now capture errors
- **Critical routes**: `/api/generate` (stream + outer catch) and `/api/components` (all error paths)
- **Fire-and-forget**: Never blocks request completion on Sentry failure
- **No-op guard**: Returns immediately when `NEXT_PUBLIC_SENTRY_DSN` not set

### Design Decision
Chose manual Sentry Envelope API over `@sentry/cloudflare` SDK to stay within Workers free tier bundle limit (3072 KiB, ~190 KiB headroom).

## Test plan
- [ ] CI passes (lint, type-check, build, unit tests)
- [ ] Build stays under 3072 KiB gzipped
- [ ] No DSN set -> no Sentry calls (no-op)
- [ ] With DSN -> errors POST to Sentry envelope endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)