### PR TITLE
fix: Exclude node_modules from electron-builder packaging

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -7,6 +7,7 @@ directories:
 files:
   - dist/**/*
   - resources/**/*
+  - "!node_modules"
 asarUnpack:
   - "**/*.node"
 mac:


### PR DESCRIPTION
## Summary
- Add `!node_modules` exclusion to electron-builder `files` config
- Fixes ASAR packaging failure in monorepo where workspace deps (symlinks) resolve outside app directory

## Root Cause
In the `desktop-release.yml` workflow, electron-builder follows the workspace symlink for `@siza/ui` to `packages/ui/`, which is outside `apps/desktop/`. This causes:
```
packages/ui/eslint.config.js must be under apps/desktop/
```

Since Vite already bundles all code (renderer, main, preload) into `dist/`, the packaged app doesn't need `node_modules` at runtime.

## Test plan
- [ ] CI passes
- [ ] After merge, re-tag `desktop-v0.1.0` to trigger release workflow
- [ ] Verify all 3 platform builds complete