### PR TITLE
fix: Move desktop deps to devDependencies for packaging

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,16 +14,7 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
-    "@siza/ui": "*",
-    "electron-store": "^10.0.0",
-    "electron-updater": "^6.0.0",
-    "lucide-react": "^0.400.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^7.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -39,7 +30,15 @@
     "vite": "^6.0.0",
     "vite-plugin-electron": "^0.28.0",
     "vite-plugin-electron-renderer": "^0.14.0",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@siza/ui": "*",
+    "electron-store": "^10.0.0",
+    "electron-updater": "^6.0.0",
+    "lucide-react": "^0.400.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0"
   },
   "description": "Siza desktop app - AI-powered UI generation with local MCP support",
   "author": "Forge Space"


### PR DESCRIPTION
## Summary
- Move all `dependencies` to `devDependencies` in desktop app `package.json`
- Vite bundles everything (renderer, main, preload) into `dist/` at build time
- With empty `dependencies`, electron-builder won't try to bundle `node_modules`
- Eliminates the workspace symlink issue where `@siza/ui` resolves outside the app directory

## Root Cause
electron-builder auto-bundles all runtime `dependencies` into the ASAR archive. In a monorepo, `@siza/ui` is a workspace symlink pointing to `packages/ui/`, which is outside `apps/desktop/`. When electron-builder follows this symlink, it fails:
```
packages/ui/eslint.config.js must be under apps/desktop/
```

Since Vite already bundles ALL code into `dist/` (615KB main, 440KB renderer, 1KB preload), no packages are needed at runtime in `node_modules`.

## Test plan
- [ ] CI passes (lint, type-check, build, test, E2E)
- [ ] After merge, re-tag `desktop-v0.1.0` to trigger release workflow
- [ ] All 3 platform builds (macOS, Linux, Windows) complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration for the desktop application to optimize build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->