### PR TITLE
fix: Add required package metadata for electron-builder

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,5 +41,12 @@
     "react-router-dom": "^7.0.0"
   },
   "description": "Siza desktop app - AI-powered UI generation with local MCP support",
-  "author": "Forge Space"
+  "author": "Forge Space",
+  "homepage": "https://github.com/Forge-Space/siza",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Forge-Space/siza.git",
+    "directory": "apps/desktop"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Add `homepage`, `repository`, and `license` to desktop package.json
- electron-builder requires `homepage` for Debian/AppImage builds

## Test plan
- [ ] CI passes
- [ ] After merge, re-tag `desktop-v0.1.0` → all platform builds complete