### PR TITLE
fix: Add author email for Debian package generation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -41,7 +41,10 @@
     "react-router-dom": "^7.0.0"
   },
   "description": "Siza desktop app - AI-powered UI generation with local MCP support",
-  "author": "Forge Space",
+  "author": {
+    "name": "Forge Space",
+    "email": "contact@forgespace.dev"
+  },
   "homepage": "https://github.com/Forge-Space/siza",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Change `author` from string to object with `name` and `email`
- electron-builder requires author email for Debian (`.deb`) packaging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include author contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->