### PR TITLE
fix: Inject build-time version in health endpoint and fix docs issues

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -20,11 +20,21 @@ export const metadata: Metadata = {
     default: 'Siza Documentation',
   },
   description: 'The Open Full-Stack AI Workspace — documentation',
+  icons: {
+    icon: '/siza-icon.png',
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: 'if(typeof __name==="undefined")globalThis.__name=function(fn){return fn}',
+          }}
+        />
+      </head>
       <body>
         <RootProvider>{children}</RootProvider>
       </body>

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -6,6 +6,9 @@ if (process.env.NODE_ENV === 'development') {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  env: {
+    APP_VERSION: require('./package.json').version,
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -4,6 +4,6 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
-    version: process.env.npm_package_version || '0.7.0',
+    version: process.env.APP_VERSION || '0.0.0',
   });
 }


### PR DESCRIPTION
## Summary
- **Health version**: Replace `process.env.npm_package_version` (unavailable in Workers runtime) with build-time `APP_VERSION` injected via `next.config.js` env from `package.json`. Health endpoint will now correctly report `0.11.0` instead of fallback `0.7.0`.
- **Docs favicon**: Add `icons` metadata pointing to existing `/siza-icon.png`, fixing 404 on `/favicon.ico`.
- **Docs `__name` error**: Add polyfill for esbuild `__name` helper that gets stripped by Cloudflare Workers bundling, fixing `ReferenceError: __name is not defined` console error.

## Test plan
- [ ] Deploy to dev and verify `GET /api/health` returns `version: "0.11.0"`
- [ ] Check docs site has favicon in browser tab
- [ ] Check docs site console has no `__name` ReferenceError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app icon to documentation site.

* **Chores**
  * Updated version tracking configuration and health check endpoint reporting for web application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->