### PR TITLE
chore: Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-02-28
+
 ### Added
 - **LivePreview Library Shims**: Generated code using lucide-react icons and shadcn/ui components now renders correctly in the preview iframe
   - `cn()` utility for Tailwind class joining
@@ -14,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 30+ shadcn/ui component stubs (Button, Card, Badge, Input, Label, Alert, Dialog, Table, Tabs, Select, etc.)
   - shadcn dark theme CSS custom properties and Tailwind color config
   - Zero server bundle cost — all shims are inline template strings in the iframe HTML
+
+### Fixed
+- Health endpoint now returns build-time injected version instead of reading package.json at runtime
+- Docs site layout and component structure fixes
 
 ## [desktop-v0.2.0] - 2026-02-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
- Bump version to 0.12.0
- Update CHANGELOG with v0.12.0 entries

## Changes included in this release

### Added
- **LivePreview Library Shims** (#130): Generated code using lucide-react icons and shadcn/ui components now renders correctly in the preview iframe
  - `cn()` utility, 25+ icon SVG shims, 30+ shadcn/ui component stubs
  - Dark theme CSS custom properties and Tailwind color config
  - Zero server bundle cost

### Fixed
- **Health endpoint** (#129): Build-time injected version instead of runtime package.json read
- **Docs site** (#129): Layout and component structure fixes

## Test plan
- [x] All 423 tests pass
- [x] Type check passes
- [x] Cloudflare Workers build succeeds
- [ ] CI passes on release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)