### PR TITLE
fix: Force dark theme and add navigation to docs landing page

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -27,7 +27,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${geist.variable} ${geistMono.variable} dark`}
+      style={{ colorScheme: 'dark' }}
+      suppressHydrationWarning
+    >
       <head>
         <script
           dangerouslySetInnerHTML={{
@@ -36,7 +41,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body>
-        <RootProvider>{children}</RootProvider>
+        <RootProvider theme={{ defaultTheme: 'dark', forcedTheme: 'dark' }}>
+          {children}
+        </RootProvider>
       </body>
     </html>
   );

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { baseOptions } from './layout.config';
 
 const quickLinks = [
   {
@@ -52,58 +54,60 @@ const ecosystem = [
 
 export default function HomePage() {
   return (
-    <main className="docs-hero">
-      <div className="docs-hero-content">
-        <h1 className="docs-hero-title">Siza Documentation</h1>
-        <p className="docs-hero-subtitle">
-          The open full-stack AI workspace — generate production-ready UI with AI. Guides, API
-          references, and examples to get you started.
-        </p>
-        <Link href="/docs" className="docs-cta">
-          Get Started
-        </Link>
-      </div>
-
-      <section className="docs-section">
-        <h2 className="docs-section-title">Quick Links</h2>
-        <div className="docs-card-grid">
-          {quickLinks.map((link) => (
-            <Link key={link.title} href={link.href} className="docs-card">
-              <span className="docs-card-icon">{link.icon}</span>
-              <h3 className="docs-card-title">{link.title}</h3>
-              <p className="docs-card-desc">{link.description}</p>
-            </Link>
-          ))}
+    <HomeLayout {...baseOptions}>
+      <main className="docs-hero">
+        <div className="docs-hero-content">
+          <h1 className="docs-hero-title">Siza Documentation</h1>
+          <p className="docs-hero-subtitle">
+            The open full-stack AI workspace — generate production-ready UI with AI. Guides, API
+            references, and examples to get you started.
+          </p>
+          <Link href="/docs" className="docs-cta">
+            Get Started
+          </Link>
         </div>
-      </section>
 
-      <section className="docs-section">
-        <h2 className="docs-section-title">Tech Stack</h2>
-        <div className="docs-tech-grid">
-          {techStack.map((tech) => (
-            <span key={tech} className="docs-tech-pill">
-              {tech}
-            </span>
-          ))}
-        </div>
-      </section>
+        <section className="docs-section">
+          <h2 className="docs-section-title">Quick Links</h2>
+          <div className="docs-card-grid">
+            {quickLinks.map((link) => (
+              <Link key={link.title} href={link.href} className="docs-card">
+                <span className="docs-card-icon">{link.icon}</span>
+                <h3 className="docs-card-title">{link.title}</h3>
+                <p className="docs-card-desc">{link.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
 
-      <section className="docs-section">
-        <h2 className="docs-section-title">Ecosystem</h2>
-        <div className="docs-ecosystem">
-          {ecosystem.map((repo, i) => (
-            <div key={repo.name}>
-              <div
-                className={`docs-ecosystem-repo ${repo.active ? 'docs-ecosystem-repo--active' : ''}`}
-              >
-                <strong>{repo.name}</strong>
-                <span>{repo.desc}</span>
+        <section className="docs-section">
+          <h2 className="docs-section-title">Tech Stack</h2>
+          <div className="docs-tech-grid">
+            {techStack.map((tech) => (
+              <span key={tech} className="docs-tech-pill">
+                {tech}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        <section className="docs-section">
+          <h2 className="docs-section-title">Ecosystem</h2>
+          <div className="docs-ecosystem">
+            {ecosystem.map((repo, i) => (
+              <div key={repo.name}>
+                <div
+                  className={`docs-ecosystem-repo ${repo.active ? 'docs-ecosystem-repo--active' : ''}`}
+                >
+                  <strong>{repo.name}</strong>
+                  <span>{repo.desc}</span>
+                </div>
+                {i < ecosystem.length - 1 && <span className="docs-ecosystem-arrow">→</span>}
               </div>
-              {i < ecosystem.length - 1 && <span className="docs-ecosystem-arrow">→</span>}
-            </div>
-          ))}
-        </div>
-      </section>
-    </main>
+            ))}
+          </div>
+        </section>
+      </main>
+    </HomeLayout>
   );
 }


### PR DESCRIPTION
## Summary
- **Force dark mode**: Add `forcedTheme: 'dark'` to Fumadocs RootProvider + `dark` class and `colorScheme: 'dark'` on html element. Prevents light-mode rendering where title text is invisible (light gray on white background).
- **Add navigation**: Wrap homepage with Fumadocs `HomeLayout` component so the landing page has the same nav bar (Siza logo, Platform link, GitHub link) as the docs pages.

## Before
- White background with nearly invisible title text on light-mode systems
- No navigation bar on the landing page

## After
- Consistent dark theme matching the main Siza app
- Navigation bar with Siza branding and links

## Test plan
- [ ] Visit https://siza-docs.uiforge.workers.dev/ — verify dark background with visible text
- [ ] Verify nav bar appears on landing page with Siza logo and links
- [ ] Navigate to /docs — verify docs pages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)