### PR TITLE
chore: Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-02-28
+
+### Fixed
+- Force dark theme on docs site landing page (removes light mode flash)
+- Add navigation links to docs landing page (Getting Started, API Reference, GitHub)
+
 ## [0.12.0] - 2026-02-28
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Version bump 0.12.0 → 0.12.1
- CHANGELOG entry for docs dark theme fix (PR #133)

## Changes since v0.12.0
- fix: Force dark theme on docs site landing page
- fix: Add navigation links to docs landing page

## Test plan
- [ ] CI passes (lint, build, test, type-check)
- [ ] Version is 0.12.1 in apps/web/package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.12.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->