### PR TITLE
chore: Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-02-28
+
+### Fixed
+- Force dark theme on docs site to prevent invisible text on light-mode systems
+- Add navigation bar to docs landing page via Fumadocs HomeLayout wrapper
+
 ## [0.12.0] - 2026-02-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
- Patch release for docs site fixes merged in PR #133

### Fixed
- Force dark theme on docs site to prevent invisible text on light-mode systems
- Add navigation bar to docs landing page via Fumadocs HomeLayout wrapper

## Test plan
- [x] CI passes (lint, type-check, build, tests)
- [x] PR #133 already merged and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version update (0.12.1) released with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->