### PR TITLE
chore: Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-02-28
+
 ### Changed
 - **Custom domain**: Migrate from `siza-web.uiforge.workers.dev` to `siza.dev`
   - Updated Supabase auth redirect URLs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
- Custom domain migration: `siza-web.uiforge.workers.dev` → `siza.dev` (PR #134, closes #64)

### Changed
- Supabase auth redirect URLs updated to siza.dev
- Cloudflare Workers custom domain routing added
- Documentation and README references updated

**Full Changelog**: https://github.com/Forge-Space/siza/compare/v0.12.1...v0.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)