### PR TITLE
chore: Add support email and Cloudflare dev domain config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Documentation: `docs.forgespace.co`
   - Dev environment: `dev.forgespace.co`
   - API: `api.forgespace.co`
-  - Email: `noreply@forgespace.co`
+  - Email: `noreply@forgespace.co` (transactional), `support@forgespace.co` (reply-to)
 
 ## [0.13.0] - 2026-02-28
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -107,8 +107,8 @@ This document outlines the security measures and configurations implemented for 
 
 ## 📞 Security Contacts
 
-- **Security Team**: [security@siza.dev]
-- **Vulnerability Reporting**: [security@siza.dev]
+- **Security Team**: [security@forgespace.co](mailto:security@forgespace.co)
+- **Vulnerability Reporting**: [security@forgespace.co](mailto:security@forgespace.co)
 - **Snyk Organization**: Configured in Snyk dashboard
 
 ## 🛠️ Security Commands

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -29,6 +29,7 @@ TOKEN_ENCRYPTION_KEY=generate-a-strong-random-key
 RESEND_API_KEY=re_xxxxx
 RESEND_FROM_EMAIL=noreply@forgespace.co
 RESEND_FROM_NAME=Siza
+RESEND_REPLY_TO_EMAIL=support@forgespace.co
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Feature Flags

--- a/apps/web/src/lib/email/service.ts
+++ b/apps/web/src/lib/email/service.ts
@@ -9,12 +9,14 @@ interface SendEmailOptions {
 
 const FROM_EMAIL = process.env.RESEND_FROM_EMAIL ?? 'noreply@forgespace.co';
 const FROM_NAME = process.env.RESEND_FROM_NAME ?? 'Siza';
+const REPLY_TO = process.env.RESEND_REPLY_TO_EMAIL ?? 'support@forgespace.co';
 
 export async function sendEmail({ to, subject, react }: SendEmailOptions) {
   const resend = getResendClient();
 
   const { data, error } = await resend.emails.send({
     from: `${FROM_NAME} <${FROM_EMAIL}>`,
+    replyTo: REPLY_TO,
     to,
     subject,
     react,

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -11,6 +11,12 @@
   "env": {
     "dev": {
       "name": "siza-web-dev",
+      "routes": [
+        {
+          "pattern": "dev.forgespace.co/*",
+          "custom_domain": true,
+        },
+      ],
     },
   },
   "routes": [

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -68,7 +68,7 @@ enable_confirmations = true
 # port = 587
 # user = "resend"
 # pass = "env(RESEND_API_KEY)"
-# admin_email = "noreply@forgespace.co"
+admin_email = "support@forgespace.co"
 # sender_name = "Siza"
 
 [auth.external.google]


### PR DESCRIPTION
## Summary
- Add `support@forgespace.co` as reply-to for all transactional emails (users can reply to automated emails)
- Add `RESEND_REPLY_TO_EMAIL` env var for configurability
- Set Supabase `admin_email` to `support@forgespace.co`
- Add `dev.forgespace.co` custom domain route for dev Worker environment
- Update SECURITY.md contacts from `siza.dev` to `forgespace.co`

## Infrastructure Checklist (post-merge)
- [ ] Add `forgespace.co` zone to Cloudflare dashboard
- [ ] Update NS records at domain registrar
- [ ] Verify `forgespace.co` domain in Resend for email sending
- [ ] Update Supabase project auth redirect URLs in dashboard

## Test plan
- [ ] Verify email sending still works with replyTo field
- [ ] Verify `wrangler dev` works with dev env config
- [ ] Type-check passes for email service changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Email handling: Configured dedicated reply-to address for customer support communications
  * System notifications: Activated admin email address for platform system messages
  * Development infrastructure: Established domain routing for the development environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->