### PR TITLE
feat: Add HTTPS dev server with mkcert

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:https": "next dev --experimental-https --experimental-https-key ./certificates/localhost+2-key.pem --experimental-https-cert ./certificates/localhost+2.pem",
     "build": "next build",
     "start": "next start",
     "lint": "eslint src --ext .ts,.tsx,.js,.jsx --max-warnings 0",


### PR DESCRIPTION
## Summary
- Add `dev:https` script to run Next.js dev server with locally-trusted SSL via mkcert
- Certificates generated for `localhost`, `127.0.0.1`, `::1` (valid until May 2028)
- Existing `*.pem` gitignore rule covers certificate files

## Usage
```bash
cd apps/web
npm run dev:https  # → https://localhost:3000 (trusted cert, green lock)
```

## Test plan
- [x] `mkcert -install` sets up local CA in macOS Keychain
- [x] `npm run dev:https` starts server on `https://localhost:3000`
- [x] Browser shows trusted certificate (no warnings)
- [x] Regular `npm run dev` still works as plain HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)