### PR TITLE
chore(release): Prepare v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - API: `api.forgespace.co`
   - Email: `noreply@forgespace.co` (transactional), `support@forgespace.co` (reply-to)
 
+## [0.13.1] - 2026-02-28
+
+### Added
+- **Test coverage boost**: 63 new unit tests across 4 new suites (#138)
+  - Quality gates validation, template validation, auth email helpers, usage limits
+- **HTTPS dev server**: `npm run dev:https` with mkcert certificates for local development (#143)
+
+### Changed
+- **Domain migration**: All URLs migrated to `forgespace.co` subdomains (#141, #142)
+  - Production: `siza.forgespace.co`, Docs: `docs.forgespace.co`, Dev: `dev.forgespace.co`
+  - Support email and Cloudflare custom domain configuration
+- **Repo cleanup**: Improved .gitignore, removed stale docs, relocated test fixtures (#140)
+
 ## [0.13.0] - 2026-02-28
 
 ### Changed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
- Bump version to v0.13.1
- Add CHANGELOG entry for 5 unreleased commits since v0.13.0

### Changes in v0.13.1
- **Test coverage**: 63 new unit tests (#138)
- **Domain migration**: All URLs to forgespace.co (#141, #142)
- **Repo cleanup**: Better .gitignore, test fixture relocation (#140)
- **HTTPS dev**: Local HTTPS with mkcert certificates (#143)

## Test plan
- [ ] CI passes (lint, type-check, build, tests)
- [ ] Version matches in package.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)