### PR TITLE
fix: Improve CodeQL security fixes with entity encoding

### DIFF
--- a/apps/api/src/services/wireframe-to-figma-enhanced.ts
+++ b/apps/api/src/services/wireframe-to-figma-enhanced.ts
@@ -189,7 +189,7 @@ function createComponentWithVariants(
     componentProperties: {},
   };
 
-  if (createVariants && elements.length > 1) {
+  if (elements.length > 1) {
     // Create variants for different states
     const variants = createComponentVariants(elements);
     baseComponent.children = variants;

--- a/apps/web/src/__tests__/lib/security/sanitize.test.ts
+++ b/apps/web/src/__tests__/lib/security/sanitize.test.ts
@@ -1,16 +1,20 @@
 import { sanitizeText, sanitizeHtml, escapeForAttribute } from '@/lib/security/sanitize';
 
 describe('sanitizeText', () => {
-  it('strips HTML tags', () => {
-    expect(sanitizeText('<b>bold</b>')).toBe('bold');
+  it('encodes HTML tags as entities', () => {
+    expect(sanitizeText('<b>bold</b>')).toBe('&lt;b&gt;bold&lt;/b&gt;');
   });
 
-  it('strips script tags with content', () => {
-    expect(sanitizeText('hello<script>alert("xss")</script>world')).toBe('helloworld');
+  it('encodes script tags', () => {
+    expect(sanitizeText('hello<script>alert("xss")</script>world')).toBe(
+      'hello&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;world'
+    );
   });
 
-  it('strips event handlers', () => {
-    expect(sanitizeText('<div onload="alert(1)">content</div>')).toBe('content');
+  it('encodes event handler attributes', () => {
+    expect(sanitizeText('<div onload="alert(1)">content</div>')).toBe(
+      '&lt;div onload=&quot;alert(1)&quot;&gt;content&lt;/div&gt;'
+    );
   });
 
   it('preserves plain text', () => {
@@ -21,26 +25,28 @@ describe('sanitizeText', () => {
     expect(sanitizeText('  hello  ')).toBe('hello');
   });
 
-  it('handles nested tags', () => {
-    expect(sanitizeText('<div><span>text</span></div>')).toBe('text');
+  it('encodes nested tags', () => {
+    expect(sanitizeText('<div><span>text</span></div>')).toBe(
+      '&lt;div&gt;&lt;span&gt;text&lt;/span&gt;&lt;/div&gt;'
+    );
   });
 
   it('handles empty string', () => {
     expect(sanitizeText('')).toBe('');
   });
 
-  it('strips multiple script tags', () => {
-    expect(sanitizeText('<script>a</script>safe<script>b</script>')).toBe('safe');
+  it('encodes ampersands in text', () => {
+    expect(sanitizeText('a & b')).toBe('a &amp; b');
   });
 });
 
 describe('sanitizeHtml', () => {
-  it('removes script tags but keeps other HTML', () => {
-    expect(sanitizeHtml('<b>bold</b><script>xss</script>')).toBe('<b>bold</b>');
+  it('encodes all HTML entities', () => {
+    expect(sanitizeHtml('<b>bold</b>')).toBe('&lt;b&gt;bold&lt;/b&gt;');
   });
 
-  it('removes event handlers', () => {
-    expect(sanitizeHtml('<div onclick="alert(1)">click</div>')).toBe('<div >click</div>');
+  it('encodes script tags', () => {
+    expect(sanitizeHtml('<script>xss</script>')).toBe('&lt;script&gt;xss&lt;/script&gt;');
   });
 });
 

--- a/apps/web/src/lib/quality/gates.ts
+++ b/apps/web/src/lib/quality/gates.ts
@@ -109,7 +109,7 @@ export function runAccessibilityCheck(code: string): QualityResult {
     }
   }
 
-  if (/tabIndex\s*=\s*[{\s]*[1-9]/.test(code)) {
+  if (/tabIndex\s*=\s*\{?\s?[1-9]/.test(code)) {
     issues.push('Positive tabIndex values harm accessibility');
   }
 

--- a/apps/web/src/lib/security/sanitize.ts
+++ b/apps/web/src/lib/security/sanitize.ts
@@ -1,35 +1,23 @@
-const SCRIPT_RE = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
-const EVENT_HANDLER_RE = /\bon\w+=\s*["'][^"']*["']/gi;
-const HTML_TAG_RE = /<[^>]*>/g;
+const HTML_ENTITIES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+};
+
+function encodeEntities(input: string): string {
+  return input.replace(/[&<>"']/g, (ch) => HTML_ENTITIES[ch] || ch);
+}
 
 export function sanitizeText(input: string): string {
-  let result = input;
-  for (let i = 0; i < 10; i++) {
-    const next = result
-      .replace(SCRIPT_RE, '')
-      .replace(EVENT_HANDLER_RE, '')
-      .replace(HTML_TAG_RE, '');
-    if (next === result) break;
-    result = next;
-  }
-  return result.trim();
+  return encodeEntities(input).trim();
 }
 
 export function sanitizeHtml(input: string): string {
-  let result = input;
-  for (let i = 0; i < 10; i++) {
-    const next = result.replace(SCRIPT_RE, '').replace(EVENT_HANDLER_RE, '');
-    if (next === result) break;
-    result = next;
-  }
-  return result.trim();
+  return encodeEntities(input).trim();
 }
 
 export function escapeForAttribute(input: string): string {
-  return input
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  return encodeEntities(input);
 }

--- a/packages/ui/src/components/generator/LivePreview.tsx
+++ b/packages/ui/src/components/generator/LivePreview.tsx
@@ -821,7 +821,7 @@ export default function LivePreview({ code, framework }: LivePreviewProps) {
 
 function stripImportsAndExports(code: string): string {
   return code
-    .replace(/^import\b[^\n]*$/gm, '')
+    .replace(/^import\s[^\n]*$/gm, '')
     .replace(/^export\s+default\s+/gm, 'const __DefaultExport__ = ')
     .replace(/^export\s+/gm, '');
 }
@@ -894,7 +894,7 @@ ${LIBRARY_SHIMS}
 
 function createVuePreviewHTML(code: string): string {
   const processed = code
-    .replace(/^import\b[^\n]*$/gm, '')
+    .replace(/^import\s[^\n]*$/gm, '')
     .replace(/export\s+default\s+/gm, 'const __VueComponent__ = ');
 
   return `<!DOCTYPE html>


### PR DESCRIPTION
## Summary
- Replace regex-based HTML stripping with entity encoding in `sanitize.ts` (resolves `js/incomplete-multi-character-sanitization` and `js/bad-tag-filter`)
- Fix ReDoS-prone regex in `gates.ts` tabIndex check (`js/polynomial-redos`)
- Remove trivially-true conditional in `wireframe-to-figma-enhanced.ts` (`js/trivial-conditional`)
- Fix import-stripping regexes in `LivePreview.tsx` to avoid ReDoS (`js/polynomial-redos`)
- Update sanitize tests for new entity encoding behavior

## Test plan
- [x] Sanitize tests pass (15/15)
- [ ] Full CI (lint, build, type-check, unit tests)
- [ ] CodeQL re-scan shows reduced alerts