### PR TITLE
fix: Docs nav + E2E billing strict mode + ecosystem count

### DIFF
--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -5,19 +5,16 @@ export const baseOptions: BaseLayoutProps = {
   nav: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <Image src="/siza-icon.png" alt="Siza" width={24} height={24} />
-        <span style={{ fontWeight: 600 }}>Siza</span>
+        <Image src="/siza-logo.svg" alt="Siza" width={20} height={20} />
+        <span style={{ fontWeight: 700, letterSpacing: '-0.02em' }}>Siza</span>
       </div>
     ),
   },
   links: [
-    {
-      text: 'Platform',
-      url: 'https://siza.forgespace.co',
-    },
-    {
-      text: 'GitHub',
-      url: 'https://github.com/Forge-Space',
-    },
+    { text: 'Docs', url: '/docs', active: 'nested-url' },
+    { text: 'API', url: '/docs/api-reference/mcp-tools' },
+    { text: 'Guides', url: '/docs/guides/first-component' },
+    { text: 'Platform', url: 'https://siza.forgespace.co', external: true },
+    { text: 'GitHub', url: 'https://github.com/Forge-Space', external: true },
   ],
 };

--- a/apps/web/e2e/billing.spec.ts
+++ b/apps/web/e2e/billing.spec.ts
@@ -74,8 +74,10 @@ test.describe('Billing Page (authenticated)', () => {
   test('should show usage charts', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/billing');
 
-    await expect(authenticatedPage.getByText('AI Generations').first()).toBeVisible();
-    await expect(authenticatedPage.getByText('Projects').first()).toBeVisible();
+    await expect(authenticatedPage.getByText('AI Generations', { exact: true })).toBeVisible();
+    await expect(
+      authenticatedPage.locator('#main-content').getByText('Projects', { exact: true })
+    ).toBeVisible();
   });
 
   test('should link to pricing page from upgrade button', async ({ authenticatedPage }) => {
@@ -213,11 +215,11 @@ test.describe('Billing Page for Subscribed User', () => {
     await seedUsageTracking(testUser.id, 42, 500);
 
     await authenticatedPage.goto('/billing');
-    await authenticatedPage.waitForLoadState('networkidle');
+    await authenticatedPage.waitForLoadState('domcontentloaded');
 
     await expect(authenticatedPage.getByText(/pro/i).first()).toBeVisible();
 
-    await expect(authenticatedPage.getByText('AI Generations').first()).toBeVisible();
+    await expect(authenticatedPage.getByText('AI Generations', { exact: true })).toBeVisible();
 
     const manageButton = authenticatedPage.getByRole('button', {
       name: /manage/i,

--- a/apps/web/src/app/(marketing)/about/page.tsx
+++ b/apps/web/src/app/(marketing)/about/page.tsx
@@ -162,7 +162,7 @@ export default function AboutPage() {
           <FadeIn className="text-center mb-10">
             <h2 className="text-3xl font-bold tracking-tight mb-3">The Forge Space Ecosystem</h2>
             <p className="text-muted-foreground max-w-xl mx-auto">
-              Siza is part of Forge Space — an open-source developer workspace. Five repositories,
+              Siza is part of Forge Space — an open-source developer workspace. Six repositories,
               MCP-native architecture, zero lock-in.
             </p>
           </FadeIn>


### PR DESCRIPTION
## Summary
- Expand docs navigation with API, Guides, and branded links
- Fix E2E billing tests: strict mode violations on AI Generations and Projects locators
- Replace fragile networkidle with domcontentloaded in billing E2E
- Scope billing Projects locator to #main-content to avoid sidebar nav collision
- Update ecosystem count from five to six repos (about page + landing E2E)

## Test plan
- [x] Fresh branch from main (no merge artifacts)
- [x] Only targeted changes (4 files)
- [ ] CI green

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized documentation navigation with dedicated Docs, API Reference, and Guides sections.
  * Updated documentation logo and styling.

* **Documentation**
  * Updated ecosystem description in the about page to reflect six repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->