### PR TITLE
fix: Docs nav + E2E billing fixes + Prettier formatting

### DIFF
--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -5,19 +5,16 @@ export const baseOptions: BaseLayoutProps = {
   nav: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <Image src="/siza-icon.png" alt="Siza" width={24} height={24} />
-        <span style={{ fontWeight: 600 }}>Siza</span>
+        <Image src="/siza-logo.svg" alt="Siza" width={20} height={20} />
+        <span style={{ fontWeight: 700, letterSpacing: '-0.02em' }}>Siza</span>
       </div>
     ),
   },
   links: [
-    {
-      text: 'Platform',
-      url: 'https://siza.forgespace.co',
-    },
-    {
-      text: 'GitHub',
-      url: 'https://github.com/Forge-Space',
-    },
+    { text: 'Docs', url: '/docs', active: 'nested-url' },
+    { text: 'API', url: '/docs/api-reference/mcp-tools' },
+    { text: 'Guides', url: '/docs/guides/first-component' },
+    { text: 'Platform', url: 'https://siza.forgespace.co', external: true },
+    { text: 'GitHub', url: 'https://github.com/Forge-Space', external: true },
   ],
 };

--- a/apps/web/e2e/billing.spec.ts
+++ b/apps/web/e2e/billing.spec.ts
@@ -213,7 +213,7 @@ test.describe('Billing Page for Subscribed User', () => {
     await seedUsageTracking(testUser.id, 42, 500);
 
     await authenticatedPage.goto('/billing');
-    await authenticatedPage.waitForLoadState('networkidle');
+    await authenticatedPage.waitForLoadState('domcontentloaded');
 
     await expect(authenticatedPage.getByText(/pro/i).first()).toBeVisible();
 

--- a/apps/web/src/app/(marketing)/about/page.tsx
+++ b/apps/web/src/app/(marketing)/about/page.tsx
@@ -162,7 +162,7 @@ export default function AboutPage() {
           <FadeIn className="text-center mb-10">
             <h2 className="text-3xl font-bold tracking-tight mb-3">The Forge Space Ecosystem</h2>
             <p className="text-muted-foreground max-w-xl mx-auto">
-              Siza is part of Forge Space — an open-source developer workspace. Five repositories,
+              Siza is part of Forge Space — an open-source developer workspace. Six repositories,
               MCP-native architecture, zero lock-in.
             </p>
           </FadeIn>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
@@ -31,7 +34,9 @@
       "eslint --fix --max-warnings 0 --no-warn-ignored",
       "prettier --write"
     ],
-    "*.{json,md,yml,yaml}": ["prettier --write"]
+    "*.{json,md,yml,yaml}": [
+      "prettier --write"
+    ]
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.1",

--- a/packages/create-siza-app/package.json
+++ b/packages/create-siza-app/package.json
@@ -7,7 +7,10 @@
     "create-siza-app": "./dist/index.js"
   },
   "main": "./dist/index.js",
-  "files": ["dist", "templates"],
+  "files": [
+    "dist",
+    "templates"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary
- Expand docs navigation with API, Guides, and branded links (forgespace.co)
- Fix E2E billing tests: strict mode violations (AI Generations, Projects locators)
- Replace fragile networkidle with domcontentloaded in billing E2E
- Scope Projects locator to #main-content (avoids sidebar nav collision)
- Update ecosystem count: five to six repos (about page + landing E2E)
- Format root package.json and create-siza-app/package.json with Prettier

## Test plan
- [x] Fresh branch from main
- [x] All Prettier formatting applied
- [ ] CI green

Generated with Claude Code