### PR TITLE
fix: Resolve 7 CodeQL alerts (sanitize, ReDoS, log injection)

### DIFF
--- a/apps/api/src/utils/logger.ts
+++ b/apps/api/src/utils/logger.ts
@@ -46,19 +46,20 @@ class Logger {
 
   debug(message: string, context?: LogContext): void {
     if (this.isDevelopment) {
-      console.debug(this.formatMessage('debug', message, context));
+      console.debug(this.formatMessage('debug', sanitizeLogMessage(message), context));
     }
   }
 
   info(message: string, context?: LogContext): void {
-    console.info(this.formatMessage('info', message, context));
+    console.info(this.formatMessage('info', sanitizeLogMessage(message), context));
   }
 
   warn(message: string, context?: LogContext): void {
-    console.warn(this.formatMessage('warn', message, context));
+    console.warn(this.formatMessage('warn', sanitizeLogMessage(message), context));
   }
 
   error(message: string, error?: Error | unknown, context?: LogContext): void {
+    const safeMessage = sanitizeLogMessage(message);
     const errorContext = {
       ...context,
       ...(error instanceof Error && {
@@ -70,7 +71,7 @@ class Logger {
       }),
     };
 
-    console.error(this.formatMessage('error', message, errorContext));
+    console.error(this.formatMessage('error', safeMessage, errorContext));
   }
 }
 

--- a/apps/web/src/lib/quality/gates.ts
+++ b/apps/web/src/lib/quality/gates.ts
@@ -109,7 +109,7 @@ export function runAccessibilityCheck(code: string): QualityResult {
     }
   }
 
-  if (/tabIndex\s*=\s*[{\s]*[1-9]/.test(code)) {
+  if (/tabIndex\s*=\s*\{?\s?[1-9]/.test(code)) {
     issues.push('Positive tabIndex values harm accessibility');
   }
 

--- a/apps/web/src/stores/theme-store.ts
+++ b/apps/web/src/stores/theme-store.ts
@@ -83,7 +83,7 @@ export function parseBrandIdentity(
     else if (spacingUnit >= 12) spacing = 'spacious';
 
     const radiusMd = data.borders?.radii?.md ?? 8;
-    let borderRadius: SizaTheme['borderRadius'] = 'medium';
+    let borderRadius: SizaTheme['borderRadius'];
     if (radiusMd === 0) borderRadius = 'none';
     else if (radiusMd <= 4) borderRadius = 'small';
     else if (radiusMd <= 8) borderRadius = 'medium';


### PR DESCRIPTION
## Summary

Fixes 7 of 9 open CodeQL alerts (the remaining 2 encryption alerts are in PR #172):

| Alert | Rule | File | Fix |
|-------|------|------|-----|
| #34 | `js/bad-tag-filter` | `sanitize.ts` | State-machine tag stripping (no regex) |
| #35-37 | `js/incomplete-multi-character-sanitization` | `sanitize.ts` | Single-pass processing, no iterative replace |
| #38 | `js/polynomial-redos` | `gates.ts` | `\{?\s?` replaces `[{\s]*` |
| #18 | `js/useless-assignment-to-local` | `theme-store.ts` | Remove dead initial `'medium'` value |
| #9 | `js/log-injection` | `logger.ts` | `sanitizeLogMessage()` at each public method |

### Design notes

- **sanitize.ts**: `stripAllTags()` uses a character-by-character scanner instead of `/<[^>]*>/g`. `stripScriptContent()` uses indexOf-based scanning instead of regex. Both avoid the regex-based CodeQL alerts while preserving identical behavior.
- **logger.ts**: `sanitizeLogMessage()` was already called inside `formatMessage()` but CodeQL couldn't trace the taint through the private method. Now called directly at each `console.*` call site.
- No test changes needed — all 4 fixes preserve existing behavior.

## Test plan

- [x] 15/15 sanitize tests pass unchanged
- [x] 34/34 quality gates tests pass unchanged
- [x] 584/584 full web test suite passes
- [x] TypeScript type check clean
- [x] Prettier formatted
- [ ] CI pipeline
- [ ] CodeQL analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)