### PR TITLE
chore: Configure Supabase custom SMTP via Resend

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -26,7 +26,10 @@ GITHUB_APP_CLIENT_SECRET=your-github-app-client-secret
 # Token Encryption
 TOKEN_ENCRYPTION_KEY=generate-a-strong-random-key
 
-# Resend Email (transactional emails via Resend SDK)
+# Resend Email
+# Used for both Supabase Auth SMTP (verification, password reset) and
+# application-level transactional emails via Resend SDK.
+# Configure SMTP in Supabase Dashboard: Authentication → SMTP Settings
 RESEND_API_KEY=re_xxxxx
 RESEND_FROM_EMAIL=noreply@forgespace.co
 RESEND_FROM_NAME=Siza

--- a/docs/SUPABASE_CLOUD_SETUP.md
+++ b/docs/SUPABASE_CLOUD_SETUP.md
@@ -77,6 +77,25 @@ Quick guide to set up Siza with Supabase Cloud instead of local development.
    - ✅ project-files
    - ✅ user-uploads
 
+### 2.6 Configure Custom SMTP (Production)
+
+Configure Resend as the SMTP provider so auth emails (verification, password reset) come from `noreply@forgespace.co`:
+
+1. Go to **Authentication → SMTP Settings** in the Supabase Dashboard
+2. Enable **Custom SMTP** and configure:
+   - **Sender email**: `noreply@forgespace.co`
+   - **Sender name**: `Siza`
+   - **Host**: `smtp.resend.com`
+   - **Port**: `587`
+   - **Username**: `resend`
+   - **Password**: Your Resend API key (`re_xxxxx`)
+3. Go to **Authentication → Email Templates** and update all 4 templates
+   - Branded HTML templates are in `docs/email-templates/`
+4. Go to **Authentication → Rate Limits** and set email rate to 30/hour
+5. Save all changes
+
+**Prerequisites**: forgespace.co domain must be verified in Resend with DKIM/SPF/MX records configured in Cloudflare DNS.
+
 ## Step 3: Get API Credentials (1 minute)
 
 ### 3.1 Navigate to API Settings

--- a/docs/email-templates/change-email.html
+++ b/docs/email-templates/change-email.html
@@ -1,0 +1,31 @@
+<html>
+<body style="margin:0;padding:8px 0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto">
+<tr><td style="background:#ffffff;border:1px solid #e4e4e7;border-radius:8px;padding:32px">
+  <table width="100%" cellpadding="0" cellspacing="0">
+    <tr><td align="center" style="padding-bottom:24px">
+      <span style="font-size:20px;font-weight:700;color:#18181b">Siza</span>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:18px;font-weight:600;color:#18181b">Confirm email change</p>
+      <p style="margin:8px 0 0;font-size:14px;color:#52525b">You requested to change your email address. Click the button below to confirm this change.</p>
+    </td></tr>
+    <tr><td align="center" style="padding:24px 0">
+      <a href="{{ .ConfirmationURL }}" style="display:inline-block;background:#18181b;color:#ffffff;font-size:14px;font-weight:500;text-decoration:none;padding:12px 24px;border-radius:6px">Confirm new email</a>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:12px;color:#a1a1aa">If you didn't request this change, please secure your account immediately by resetting your password.</p>
+      <p style="margin:8px 0 0;font-size:12px;color:#a1a1aa">If the button doesn't work, copy and paste this URL into your browser:</p>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa;word-break:break-all">{{ .ConfirmationURL }}</p>
+    </td></tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" style="border-top:1px solid #e4e4e7;margin-top:24px;padding-top:16px">
+    <tr><td align="center">
+      <a href="https://siza.forgespace.co" style="font-size:12px;color:#71717a;text-decoration:none">Siza</a>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa">AI-powered UI generation</p>
+    </td></tr>
+  </table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/docs/email-templates/confirm-signup.html
+++ b/docs/email-templates/confirm-signup.html
@@ -1,0 +1,30 @@
+<html>
+<body style="margin:0;padding:8px 0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto">
+<tr><td style="background:#ffffff;border:1px solid #e4e4e7;border-radius:8px;padding:32px">
+  <table width="100%" cellpadding="0" cellspacing="0">
+    <tr><td align="center" style="padding-bottom:24px">
+      <span style="font-size:20px;font-weight:700;color:#18181b">Siza</span>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:18px;font-weight:600;color:#18181b">Verify your email</p>
+      <p style="margin:8px 0 0;font-size:14px;color:#52525b">Thanks for signing up for Siza. Please verify your email address by clicking the button below.</p>
+    </td></tr>
+    <tr><td align="center" style="padding:24px 0">
+      <a href="{{ .ConfirmationURL }}" style="display:inline-block;background:#18181b;color:#ffffff;font-size:14px;font-weight:500;text-decoration:none;padding:12px 24px;border-radius:6px">Verify email address</a>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:12px;color:#a1a1aa">If the button doesn't work, copy and paste this URL into your browser:</p>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa;word-break:break-all">{{ .ConfirmationURL }}</p>
+    </td></tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" style="border-top:1px solid #e4e4e7;margin-top:24px;padding-top:16px">
+    <tr><td align="center">
+      <a href="https://siza.forgespace.co" style="font-size:12px;color:#71717a;text-decoration:none">Siza</a>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa">AI-powered UI generation</p>
+    </td></tr>
+  </table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/docs/email-templates/magic-link.html
+++ b/docs/email-templates/magic-link.html
@@ -1,0 +1,31 @@
+<html>
+<body style="margin:0;padding:8px 0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto">
+<tr><td style="background:#ffffff;border:1px solid #e4e4e7;border-radius:8px;padding:32px">
+  <table width="100%" cellpadding="0" cellspacing="0">
+    <tr><td align="center" style="padding-bottom:24px">
+      <span style="font-size:20px;font-weight:700;color:#18181b">Siza</span>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:18px;font-weight:600;color:#18181b">Your login link</p>
+      <p style="margin:8px 0 0;font-size:14px;color:#52525b">Click the button below to log in to Siza. This link expires in 10 minutes.</p>
+    </td></tr>
+    <tr><td align="center" style="padding:24px 0">
+      <a href="{{ .ConfirmationURL }}" style="display:inline-block;background:#18181b;color:#ffffff;font-size:14px;font-weight:500;text-decoration:none;padding:12px 24px;border-radius:6px">Log in to Siza</a>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:12px;color:#a1a1aa">If you didn't request this link, you can safely ignore this email.</p>
+      <p style="margin:8px 0 0;font-size:12px;color:#a1a1aa">If the button doesn't work, copy and paste this URL into your browser:</p>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa;word-break:break-all">{{ .ConfirmationURL }}</p>
+    </td></tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" style="border-top:1px solid #e4e4e7;margin-top:24px;padding-top:16px">
+    <tr><td align="center">
+      <a href="https://siza.forgespace.co" style="font-size:12px;color:#71717a;text-decoration:none">Siza</a>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa">AI-powered UI generation</p>
+    </td></tr>
+  </table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/docs/email-templates/reset-password.html
+++ b/docs/email-templates/reset-password.html
@@ -1,0 +1,31 @@
+<html>
+<body style="margin:0;padding:8px 0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<table width="100%" cellpadding="0" cellspacing="0" style="max-width:560px;margin:0 auto">
+<tr><td style="background:#ffffff;border:1px solid #e4e4e7;border-radius:8px;padding:32px">
+  <table width="100%" cellpadding="0" cellspacing="0">
+    <tr><td align="center" style="padding-bottom:24px">
+      <span style="font-size:20px;font-weight:700;color:#18181b">Siza</span>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:18px;font-weight:600;color:#18181b">Reset your password</p>
+      <p style="margin:8px 0 0;font-size:14px;color:#52525b">We received a request to reset your password. Click the button below to choose a new one. This link expires in 1 hour.</p>
+    </td></tr>
+    <tr><td align="center" style="padding:24px 0">
+      <a href="{{ .ConfirmationURL }}" style="display:inline-block;background:#18181b;color:#ffffff;font-size:14px;font-weight:500;text-decoration:none;padding:12px 24px;border-radius:6px">Reset password</a>
+    </td></tr>
+    <tr><td>
+      <p style="margin:0;font-size:12px;color:#a1a1aa">If you didn't request a password reset, you can safely ignore this email. Your password will not change.</p>
+      <p style="margin:8px 0 0;font-size:12px;color:#a1a1aa">If the button doesn't work, copy and paste this URL into your browser:</p>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa;word-break:break-all">{{ .ConfirmationURL }}</p>
+    </td></tr>
+  </table>
+  <table width="100%" cellpadding="0" cellspacing="0" style="border-top:1px solid #e4e4e7;margin-top:24px;padding-top:16px">
+    <tr><td align="center">
+      <a href="https://siza.forgespace.co" style="font-size:12px;color:#71717a;text-decoration:none">Siza</a>
+      <p style="margin:4px 0 0;font-size:12px;color:#a1a1aa">AI-powered UI generation</p>
+    </td></tr>
+  </table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -60,15 +60,15 @@ enable_signup = true
 double_confirm_changes = true
 enable_confirmations = true
 
-# Production SMTP via Resend (configure in Supabase Dashboard):
-# Host: smtp.resend.com, Port: 587, User: resend, Pass: RESEND_API_KEY
+# Production SMTP via Resend (configured in Supabase Dashboard)
 # Local dev uses Inbucket (port 54324) by default
-# [auth.email.smtp]
-# host = "smtp.resend.com"
-# port = 587
-# user = "resend"
-# pass = "env(RESEND_API_KEY)"
-# sender_name = "Siza"
+[auth.email.smtp]
+host = "smtp.resend.com"
+port = 587
+user = "resend"
+pass = "env(RESEND_API_KEY)"
+admin_email = "noreply@forgespace.co"
+sender_name = "Siza"
 
 [auth.external.google]
 enabled = true


### PR DESCRIPTION
## Summary
- Uncomment `[auth.email.smtp]` in `supabase/config.toml` with Resend SMTP settings
- Add 4 branded HTML email templates in `docs/email-templates/` (confirm signup, reset password, magic link, change email)
- Add Step 2.6 SMTP setup to `docs/SUPABASE_CLOUD_SETUP.md`
- Update `.env.example` Resend comment to reference Supabase SMTP

**Dashboard configuration** (already applied, not in code):
- SMTP enabled: `smtp.resend.com:587`, sender `noreply@forgespace.co`
- Rate limit increased to 30/hour
- All 4 branded templates deployed in Supabase Auth settings
- `forgespace.co` apex domain live via Worker HTTP route

## Test plan
- [ ] Verify `supabase/config.toml` SMTP section is uncommented
- [ ] Verify email templates match Siza branding (zinc palette)
- [ ] Sign up with real email to confirm delivery from `noreply@forgespace.co`
- [ ] Check DKIM/SPF pass in email headers