### PR TITLE
chore: Sync all package versions to v0.17.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.18.0",
+  "version": "0.17.0",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
- Aligns `apps/web/package.json` from 0.16.0 → 0.17.0
- Reverts root `package.json` from premature 0.18.0 → 0.17.0

Hook-created release commits drifted versions — this syncs everything to the actual release.

## Test plan
- [ ] Version check: both package.json files show 0.17.0