### PR TITLE
feat: Add cost controls to Anthropic fallback chain

### DIFF
--- a/apps/web/src/lib/services/fallback-limiter.ts
+++ b/apps/web/src/lib/services/fallback-limiter.ts
@@ -1,0 +1,32 @@
+const MAX_DAILY_FALLBACKS = 50;
+
+let fallbackCount = 0;
+let currentDate = '';
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function canUseFallback(): boolean {
+  const date = today();
+  if (date !== currentDate) {
+    currentDate = date;
+    fallbackCount = 0;
+  }
+  return fallbackCount < MAX_DAILY_FALLBACKS;
+}
+
+export function recordFallback(): void {
+  const date = today();
+  if (date !== currentDate) {
+    currentDate = date;
+    fallbackCount = 0;
+  }
+  fallbackCount++;
+}
+
+export function getFallbackUsage(): { used: number; limit: number } {
+  const date = today();
+  if (date !== currentDate) return { used: 0, limit: MAX_DAILY_FALLBACKS };
+  return { used: fallbackCount, limit: MAX_DAILY_FALLBACKS };
+}


### PR DESCRIPTION
## Summary
- Switch fallback model from Claude Sonnet to Haiku (4x cheaper per request)
- Add daily rate limiter (50 fallbacks/day cap, ~$0.50/day worst case)
- When cap is reached, original quota error surfaces to user (no silent failure)

## Files
- `apps/web/src/lib/services/fallback-limiter.ts` — New in-memory daily rate limiter
- `apps/web/src/lib/services/provider-router.ts` — Haiku model + rate limit check

## Test plan
- [x] `tsc --noEmit` clean
- [x] 584 unit tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)