### PR TITLE
feat: Add framework configs to create-siza-app

### DIFF
--- a/packages/create-siza-app/package.json
+++ b/packages/create-siza-app/package.json
@@ -8,8 +8,7 @@
   },
   "main": "./dist/index.js",
   "files": [
-    "dist",
-    "templates"
+    "dist"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Generated projects now include framework-specific config files needed to boot:
  - **Next.js**: `next.config.ts`
  - **React/Vite**: `vite.config.ts` + `index.html` + `src/main.tsx`
  - **Vue/Vite**: `vite.config.ts` + `index.html` + `src/main.ts`
  - **SvelteKit**: `svelte.config.js` + `vite.config.ts` + `src/app.html` + `src/routes/+layout.svelte`
- Fixed CSS path for Next.js projects (`src/app/globals.css` instead of `src/globals.css`)
- Fixed `writePackageJson` to use proper objects for scripts (was `JSON.parse` of string literals)
- Added Vue/Svelte template conversion helpers (`convertToVueTemplate`, `convertToSvelteTemplate`)
- Removed non-existent `templates` from package.json `files` field

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Next.js generation: `next.config.ts` + `src/app/globals.css` + `layout.tsx` + `page.tsx`
- [x] React/Vite generation: `vite.config.ts` + `index.html` + `main.tsx` + `App.tsx`
- [x] Vue/Vite generation: `vite.config.ts` + `index.html` + `main.ts` + `App.vue`
- [x] SvelteKit generation: `svelte.config.js` + `vite.config.ts` + `app.html` + `+layout.svelte` + `+page.svelte`
- [x] MCP config (`.mcp.json`) generated when `--mcp` flag set
- [ ] CI passes