### PR TITLE
feat: Add cost controls to Anthropic fallback chain

### DIFF
--- a/apps/web/src/lib/services/fallback-limiter.ts
+++ b/apps/web/src/lib/services/fallback-limiter.ts
@@ -1,0 +1,32 @@
+const MAX_DAILY_FALLBACKS = 50;
+
+let fallbackCount = 0;
+let currentDate = '';
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function canUseFallback(): boolean {
+  const date = today();
+  if (date !== currentDate) {
+    currentDate = date;
+    fallbackCount = 0;
+  }
+  return fallbackCount < MAX_DAILY_FALLBACKS;
+}
+
+export function recordFallback(): void {
+  const date = today();
+  if (date !== currentDate) {
+    currentDate = date;
+    fallbackCount = 0;
+  }
+  fallbackCount++;
+}
+
+export function getFallbackUsage(): { used: number; limit: number } {
+  const date = today();
+  if (date !== currentDate) return { used: 0, limit: MAX_DAILY_FALLBACKS };
+  return { used: fallbackCount, limit: MAX_DAILY_FALLBACKS };
+}


### PR DESCRIPTION
## Summary
- Add daily rate limiter capping fallback usage at 50 requests/day (~$0.50/day max cost)
- Switch fallback model from Claude Sonnet 4 to Claude Haiku 4.5 (4x cheaper per request)
- Guard fallback with `canUseFallback()` check before invoking Anthropic API

## Changes
| File | Change |
|------|--------|
| `fallback-limiter.ts` | **New** — In-memory daily rate limiter with auto-reset |
| `provider-router.ts` | Import limiter, add guard + recording, switch to Haiku model |

## Cost Analysis
- **Before**: Unbounded Sonnet fallback ($3/$15 per MTok) — no cap
- **After**: Haiku at 50/day = ~$0.50/day max (~$15/month ceiling)
- In-memory counter resets per Worker isolate (conservative — each isolate has its own counter)

## Test plan
- [ ] `cd apps/web && npx jest --forceExit` passes
- [ ] Type check: `npm run type-check`
- [ ] Deploy to dev with `ANTHROPIC_API_KEY` set
- [ ] Trigger Gemini 429 → verify Haiku fallback activates
- [ ] Verify 51st fallback in same day returns quota error to user

🤖 Generated with [Claude Code](https://claude.com/claude-code)