### PR TITLE
chore: Configure Supabase SMTP via Resend with branded email templates

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -68,3 +68,6 @@ NEXT_PUBLIC_GA_TRACKING_ID=
 NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_ENVIRONMENT=development
 NEXT_PUBLIC_SENTRY_RELEASE=
+
+# Supabase SMTP (Resend API key for transactional emails)
+# SMTP_PASS=re_xxxxxxxxxxxx

--- a/docs/email-templates/change-email.html
+++ b/docs/email-templates/change-email.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Confirm email change - Siza</title>
+    <style>
+      body { margin: 0; padding: 0; background-color: #09090b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      .container { max-width: 480px; margin: 0 auto; padding: 40px 24px; }
+      .card { background-color: #18181b; border: 1px solid #27272a; border-radius: 12px; padding: 32px; }
+      .logo { font-size: 24px; font-weight: 700; color: #fafafa; margin-bottom: 24px; }
+      .logo span { color: #7c3aed; }
+      h1 { color: #fafafa; font-size: 20px; font-weight: 600; margin: 0 0 12px 0; }
+      p { color: #a1a1aa; font-size: 14px; line-height: 1.6; margin: 0 0 16px 0; }
+      .btn { display: inline-block; background-color: #7c3aed; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-size: 14px; font-weight: 500; margin: 8px 0 24px 0; }
+      .btn:hover { background-color: #6d28d9; }
+      .footer { color: #52525b; font-size: 12px; text-align: center; margin-top: 24px; }
+      .footer a { color: #7c3aed; text-decoration: none; }
+      .divider { border: none; border-top: 1px solid #27272a; margin: 24px 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+      <div class="card">
+        <div class="logo"><span>S</span>iza</div>
+        <h1>Confirm your new email</h1>
+        <p>Click the button below to confirm your new email address.</p>
+        <a href="{{ .ConfirmationURL }}" class="btn">Confirm Email Change</a>
+        <hr class="divider">
+        <p style="font-size: 12px; color: #52525b;">If you didn't request this, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        <p>&copy; 2026 Siza by <a href="https://forgespace.co">Forge Space</a></p>
+      </div>
+    </div>
+</body>
+</html>

--- a/docs/email-templates/confirm-signup.html
+++ b/docs/email-templates/confirm-signup.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Confirm your email - Siza</title>
+    <style>
+      body { margin: 0; padding: 0; background-color: #09090b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      .container { max-width: 480px; margin: 0 auto; padding: 40px 24px; }
+      .card { background-color: #18181b; border: 1px solid #27272a; border-radius: 12px; padding: 32px; }
+      .logo { font-size: 24px; font-weight: 700; color: #fafafa; margin-bottom: 24px; }
+      .logo span { color: #7c3aed; }
+      h1 { color: #fafafa; font-size: 20px; font-weight: 600; margin: 0 0 12px 0; }
+      p { color: #a1a1aa; font-size: 14px; line-height: 1.6; margin: 0 0 16px 0; }
+      .btn { display: inline-block; background-color: #7c3aed; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-size: 14px; font-weight: 500; margin: 8px 0 24px 0; }
+      .btn:hover { background-color: #6d28d9; }
+      .footer { color: #52525b; font-size: 12px; text-align: center; margin-top: 24px; }
+      .footer a { color: #7c3aed; text-decoration: none; }
+      .divider { border: none; border-top: 1px solid #27272a; margin: 24px 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+      <div class="card">
+        <div class="logo"><span>S</span>iza</div>
+        <h1>Confirm your email</h1>
+        <p>Thanks for signing up! Click the button below to verify your email address and get started.</p>
+        <a href="{{ .ConfirmationURL }}" class="btn">Confirm Email</a>
+        <hr class="divider">
+        <p style="font-size: 12px; color: #52525b;">If you didn't request this, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        <p>&copy; 2026 Siza by <a href="https://forgespace.co">Forge Space</a></p>
+      </div>
+    </div>
+</body>
+</html>

--- a/docs/email-templates/magic-link.html
+++ b/docs/email-templates/magic-link.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign in to Siza</title>
+    <style>
+      body { margin: 0; padding: 0; background-color: #09090b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      .container { max-width: 480px; margin: 0 auto; padding: 40px 24px; }
+      .card { background-color: #18181b; border: 1px solid #27272a; border-radius: 12px; padding: 32px; }
+      .logo { font-size: 24px; font-weight: 700; color: #fafafa; margin-bottom: 24px; }
+      .logo span { color: #7c3aed; }
+      h1 { color: #fafafa; font-size: 20px; font-weight: 600; margin: 0 0 12px 0; }
+      p { color: #a1a1aa; font-size: 14px; line-height: 1.6; margin: 0 0 16px 0; }
+      .btn { display: inline-block; background-color: #7c3aed; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-size: 14px; font-weight: 500; margin: 8px 0 24px 0; }
+      .btn:hover { background-color: #6d28d9; }
+      .footer { color: #52525b; font-size: 12px; text-align: center; margin-top: 24px; }
+      .footer a { color: #7c3aed; text-decoration: none; }
+      .divider { border: none; border-top: 1px solid #27272a; margin: 24px 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+      <div class="card">
+        <div class="logo"><span>S</span>iza</div>
+        <h1>Sign in with magic link</h1>
+        <p>Click the button below to sign in to your Siza account. This link expires in 10 minutes.</p>
+        <a href="{{ .ConfirmationURL }}" class="btn">Sign In</a>
+        <hr class="divider">
+        <p style="font-size: 12px; color: #52525b;">If you didn't request this, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        <p>&copy; 2026 Siza by <a href="https://forgespace.co">Forge Space</a></p>
+      </div>
+    </div>
+</body>
+</html>

--- a/docs/email-templates/reset-password.html
+++ b/docs/email-templates/reset-password.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reset your password - Siza</title>
+    <style>
+      body { margin: 0; padding: 0; background-color: #09090b; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+      .container { max-width: 480px; margin: 0 auto; padding: 40px 24px; }
+      .card { background-color: #18181b; border: 1px solid #27272a; border-radius: 12px; padding: 32px; }
+      .logo { font-size: 24px; font-weight: 700; color: #fafafa; margin-bottom: 24px; }
+      .logo span { color: #7c3aed; }
+      h1 { color: #fafafa; font-size: 20px; font-weight: 600; margin: 0 0 12px 0; }
+      p { color: #a1a1aa; font-size: 14px; line-height: 1.6; margin: 0 0 16px 0; }
+      .btn { display: inline-block; background-color: #7c3aed; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-size: 14px; font-weight: 500; margin: 8px 0 24px 0; }
+      .btn:hover { background-color: #6d28d9; }
+      .footer { color: #52525b; font-size: 12px; text-align: center; margin-top: 24px; }
+      .footer a { color: #7c3aed; text-decoration: none; }
+      .divider { border: none; border-top: 1px solid #27272a; margin: 24px 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+      <div class="card">
+        <div class="logo"><span>S</span>iza</div>
+        <h1>Reset your password</h1>
+        <p>We received a request to reset your password. Click the button below to choose a new one.</p>
+        <a href="{{ .ConfirmationURL }}" class="btn">Reset Password</a>
+        <hr class="divider">
+        <p style="font-size: 12px; color: #52525b;">If you didn't request this, you can safely ignore this email.</p>
+      </div>
+      <div class="footer">
+        <p>&copy; 2026 Siza by <a href="https://forgespace.co">Forge Space</a></p>
+      </div>
+    </div>
+</body>
+</html>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -60,15 +60,15 @@ enable_signup = true
 double_confirm_changes = true
 enable_confirmations = true
 
-# Production SMTP via Resend (configure in Supabase Dashboard):
-# Host: smtp.resend.com, Port: 587, User: resend, Pass: RESEND_API_KEY
+# Production SMTP via Resend
 # Local dev uses Inbucket (port 54324) by default
-# [auth.email.smtp]
-# host = "smtp.resend.com"
-# port = 587
-# user = "resend"
-# pass = "env(RESEND_API_KEY)"
-# sender_name = "Siza"
+[auth.email.smtp]
+admin_email = "noreply@forgespace.co"
+host = "smtp.resend.com"
+port = 587
+user = "resend"
+pass = "env(SMTP_PASS)"
+sender_name = "Siza"
 
 [auth.external.google]
 enabled = true


### PR DESCRIPTION
## Summary
- Uncomment and configure `[auth.email.smtp]` in `supabase/config.toml` for Resend SMTP
- Add 4 branded HTML email templates (confirm signup, reset password, magic link, change email)
- Add `SMTP_PASS` reference to `.env.example`

## Details
- SMTP: `smtp.resend.com:587`, admin email `noreply@forgespace.co`, sender "Siza"
- Templates use dark theme with `#7c3aed` purple accent matching Siza branding
- Templates use Supabase `{{ .ConfirmationURL }}` variable
- Local dev continues using Inbucket (no behavior change)

## Test plan
- [ ] Verify `supabase/config.toml` SMTP section is properly formatted
- [ ] Verify email templates render correctly in browser
- [ ] Verify CI passes (no code changes, config + HTML only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)