### PR TITLE
fix: Sanitize full log output for CodeQL log-injection

### DIFF
--- a/apps/api/src/utils/logger.ts
+++ b/apps/api/src/utils/logger.ts
@@ -9,6 +9,10 @@ interface LogContext {
 class Logger {
   private isDevelopment = env.NODE_ENV === 'development';
 
+  private sanitize(msg: string): string {
+    return msg.replace(/[\r\n]+/g, ' ');
+  }
+
   private formatMessage(level: LogLevel, message: string, context?: LogContext): string {
     const timestamp = new Date().toISOString();
     const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
@@ -29,23 +33,22 @@ class Logger {
 
   debug(message: string, context?: LogContext): void {
     if (this.isDevelopment) {
-      const safe = message.replace(/[\r\n]+/g, ' ');
-      console.debug(this.formatMessage('debug', safe, context));
+      const output = this.formatMessage('debug', message, context);
+      console.debug(this.sanitize(output));
     }
   }
 
   info(message: string, context?: LogContext): void {
-    const safe = message.replace(/[\r\n]+/g, ' ');
-    console.info(this.formatMessage('info', safe, context));
+    const output = this.formatMessage('info', message, context);
+    console.info(this.sanitize(output));
   }
 
   warn(message: string, context?: LogContext): void {
-    const safe = message.replace(/[\r\n]+/g, ' ');
-    console.warn(this.formatMessage('warn', safe, context));
+    const output = this.formatMessage('warn', message, context);
+    console.warn(this.sanitize(output));
   }
 
   error(message: string, error?: Error | unknown, context?: LogContext): void {
-    const safe = message.replace(/[\r\n]+/g, ' ');
     const errorContext = {
       ...context,
       ...(error instanceof Error && {
@@ -56,8 +59,8 @@ class Logger {
         },
       }),
     };
-
-    console.error(this.formatMessage('error', safe, errorContext));
+    const output = this.formatMessage('error', message, errorContext);
+    console.error(this.sanitize(output));
   }
 }
 


### PR DESCRIPTION
Sanitize the complete formatted output (message + context) before console calls, not just the message parameter. CodeQL tracks taint through formatMessage to console.