### PR TITLE
fix: Wire conversation context through refinement flow

### DIFF
--- a/apps/web/src/app/(dashboard)/generate/generate-client.tsx
+++ b/apps/web/src/app/(dashboard)/generate/generate-client.tsx
@@ -117,9 +117,14 @@ function GeneratePageClient() {
   const handleRefine = useCallback(
     async (refinementPrompt: string) => {
       if (!lastFormOptions) return;
-      generation.startRefinement(refinementPrompt, lastFormOptions);
+      generation.startGeneration({
+        ...lastFormOptions,
+        parentGenerationId: generationId ?? undefined,
+        previousCode: generatedCode,
+        refinementPrompt,
+      });
     },
-    [generation, lastFormOptions]
+    [generation, lastFormOptions, generationId, generatedCode]
   );
 
   const handleNewGeneration = useCallback(() => {
@@ -145,6 +150,19 @@ function GeneratePageClient() {
     },
     [generation]
   );
+
+  useEffect(() => {
+    if (
+      generation.code &&
+      !generation.isGenerating &&
+      !generation.error &&
+      generation.parentGenerationId
+    ) {
+      setGeneratedCode(generation.code);
+      setGenerationId(generation.parentGenerationId);
+      setIsGenerating(false);
+    }
+  }, [generation.code, generation.isGenerating, generation.error, generation.parentGenerationId]);
 
   const handlePushToGitHub = async () => {
     if (!generatedCode || !projectId) return;

--- a/apps/web/src/components/generator/GeneratorForm.tsx
+++ b/apps/web/src/components/generator/GeneratorForm.tsx
@@ -153,6 +153,8 @@ export default function GeneratorForm({
       onGenerate(generation.code, {
         ...currentSettings,
         qualityReport: generation.qualityReport,
+        generationId: generation.parentGenerationId,
+        conversationTurn: generation.conversationTurn,
         formOptions: {
           framework: framework as 'react' | 'vue' | 'angular' | 'svelte',
           componentLibrary: currentSettings.componentLibrary || 'none',


### PR DESCRIPTION
## Summary

- Fix `handleRefine` to pass `generationId` and `generatedCode` explicitly via `startGeneration()` instead of relying on `startRefinement()` which reads from the hook's empty internal state
- Add sync `useEffect` to propagate refinement results (code, generationId) from the generation hook back to page state
- Pass `generationId` and `conversationTurn` from `GeneratorForm` through the `onGenerate` callback to enable conversation chaining between initial generation and refinements

## Context

The conversation mode backend was wired to the frontend in #194, but the refinement flow had a data flow gap: `handleRefine` called `startRefinement()` which reads `parentGenerationId` from the hook's internal state — but the initial generation happened in `GeneratorForm`'s hook instance, not `generate-client`'s. This caused refinements to be treated as fresh generations instead of chaining to the conversation tree.

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 18 useGeneration tests pass (including 5 conversation state tests)
- [x] Full test suite passes (589 tests, 46 suites)
- [ ] Manual: Generate component, then refine — verify SSE sends `parentGenerationId`
- [ ] Manual: Verify `ENABLE_CONVERSATION_MODE=false` shows zero conversation UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)