### PR TITLE
chore: Finalize v0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.18.0] - 2026-03-01
 
+### Added
+- **AI generation v2 wiring**: Conversation mode, generation history panel, design analysis integration
+  - Conversation chaining with `parentGenerationId` and 10-turn max
+  - GenerationHistory Sheet sidebar for browsing/forking past generations
+  - `ENABLE_DESIGN_ANALYSIS` and `ENABLE_CONVERSATION_MODE` feature flags enabled
+- **create-siza-app framework configs**: Framework-specific config files and entry points (Next.js, React/Vite, Vue/Vite, SvelteKit)
+- **Supabase SMTP via Resend**: Branded email templates for signup confirmation, password reset, magic link, and email change
+
 ### Security
-- **Encryption hardening**: Explicit AES key/IV derivation with PBKDF2 hashing, replacing implicit key handling
-- **CodeQL fixes**: Logger sanitization, quality gates regex, sanitize library improvements, theme store safety
+- **Encryption hardening**: PBKDF2 key derivation (600K iterations) with explicit AES IV, replacing implicit EVP_BytesToKey
+- **CodeQL fixes**: Logger output sanitization (inline taint tracking), iterative HTML sanitizer, PBKDF2 API key fingerprinting
+- AES encryption alert dismissed as false positive (BYOK needs reversible encryption)
 
 ### Fixed
-- **Docs site**: Navigation links, CSS overhaul (globals.css), installation/quality-gates/templates content updates
-- **Docs deployment**: Updated wrangler.jsonc configuration
+- **Docs site**: Navigation links, CSS overhaul, content updates
 - **E2E tests**: Billing page strict mode selectors, about page content
-- **Prettier**: Normalize create-siza-app package.json formatting
+- **Prettier**: Normalize package.json formatting across monorepo
 
 ## [0.17.0] - 2026-03-01
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.16.0",
+  "version": "0.18.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Update CHANGELOG [0.18.0] with all changes since v0.17.0:
  - AI generation v2 wiring (conversation, history, design analysis)
  - create-siza-app framework configs
  - Supabase SMTP via Resend
  - PBKDF2 600K encryption hardening + CodeQL fixes
- Sync apps/web version to 0.18.0 (was 0.16.0)

## Post-merge
- Tag HEAD as v0.18.0
- Create GitHub release

## Test plan
- [ ] CI passes (lint, build, tests, type-check)
- [ ] CHANGELOG accurately reflects all commits since v0.17.0