### PR TITLE
fix: Wire refinement data flow for conversation mode

### DIFF
--- a/apps/web/src/app/(dashboard)/generate/generate-client.tsx
+++ b/apps/web/src/app/(dashboard)/generate/generate-client.tsx
@@ -114,13 +114,24 @@ function GeneratePageClient() {
     []
   );
 
-  const handleRefine = useCallback(
-    async (refinementPrompt: string) => {
-      if (!lastFormOptions) return;
-      generation.startRefinement(refinementPrompt, lastFormOptions);
-    },
-    [generation, lastFormOptions]
-  );
+  const handleRefine = async (refinementPrompt: string) => {
+    if (!lastFormOptions) return;
+    setIsGenerating(true);
+    try {
+      const result = await generation.startGeneration({
+        ...lastFormOptions,
+        parentGenerationId: generationId ?? undefined,
+        previousCode: generatedCode,
+        refinementPrompt,
+      });
+      if (result) {
+        setGeneratedCode(result.code);
+        setGenerationId(result.generationId);
+      }
+    } finally {
+      setIsGenerating(false);
+    }
+  };
 
   const handleNewGeneration = useCallback(() => {
     generation.reset();
@@ -305,7 +316,7 @@ function GeneratePageClient() {
 
       {generatedCode && !isGenerating && (
         <div className="mt-4 space-y-3">
-          {conversationEnabled && generation.parentGenerationId && (
+          {conversationEnabled && generationId && (
             <RefinementInput
               onRefine={handleRefine}
               onNewGeneration={handleNewGeneration}

--- a/apps/web/src/components/generator/GeneratorForm.tsx
+++ b/apps/web/src/components/generator/GeneratorForm.tsx
@@ -153,6 +153,7 @@ export default function GeneratorForm({
       onGenerate(generation.code, {
         ...currentSettings,
         qualityReport: generation.qualityReport,
+        generationId: generation.parentGenerationId,
         formOptions: {
           framework: framework as 'react' | 'vue' | 'angular' | 'svelte',
           componentLibrary: currentSettings.componentLibrary || 'none',
@@ -171,6 +172,7 @@ export default function GeneratorForm({
     generation.isGenerating,
     generation.error,
     generation.qualityReport,
+    generation.parentGenerationId,
     onGenerate,
     currentSettings,
     framework,

--- a/apps/web/src/hooks/use-generation.ts
+++ b/apps/web/src/hooks/use-generation.ts
@@ -64,6 +64,7 @@ export function useGeneration(_projectId?: string) {
 
         let chunkCount = 0;
         let code = '';
+        let resultGenerationId: string | null = null;
 
         for await (const event of streamGeneration(options)) {
           if (abortControllerRef.current?.signal.aborted) break;
@@ -99,6 +100,7 @@ export function useGeneration(_projectId?: string) {
               break;
 
             case 'complete':
+              resultGenerationId = event.generationId ?? null;
               setState((prev) => ({
                 ...prev,
                 code,
@@ -123,12 +125,16 @@ export function useGeneration(_projectId?: string) {
           if (prev.isGenerating) return { ...prev, isGenerating: false };
           return prev;
         });
+
+        return { code, generationId: resultGenerationId };
       } catch (error) {
         setState((prev) => ({
           ...prev,
           error: error instanceof Error ? error.message : 'Unknown error',
           isGenerating: false,
         }));
+
+        return null;
       }
     },
     []


### PR DESCRIPTION
## Summary
- **startGeneration** now returns `{code, generationId}` so callers can use the result in event handlers instead of syncing via useEffect
- **handleRefine** calls `startGeneration()` directly with page-level state (`generationId`, `generatedCode`), fixing the data flow gap where the page hook's internal state was empty after initial generation
- **GeneratorForm** passes `generationId` through the `onGenerate` callback so the page knows which generation to chain refinements from
- **RefinementInput** renders based on page `generationId` (set by any generation source) instead of the page hook's `parentGenerationId` (only set after refinement)

## Problem
The initial generation runs through GeneratorForm's own `useGeneration` hook, but refinement ran through the page-level hook. The page hook's `parentGenerationId` and `code` were always empty, so `startRefinement()` treated every refinement as a fresh generation. PR #200 attempted to fix this with a sync useEffect, but React Compiler rejected it ("Calling setState synchronously within an effect can trigger cascading renders").

## Solution
Make `startGeneration` return its result, then use it in `handleRefine`'s async event handler — no useEffect needed. This is React Compiler-compatible because setState happens in response to a user action (clicking refine), not as an effect side-effect.

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on all 3 files — zero errors, zero warnings
- [x] `npx jest --forceExit` — 589 tests pass
- [ ] CI Lint (React Compiler) — should pass (no useEffect setState)
- [ ] Manual: generate component → refine → verify code chains correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)