### PR TITLE
fix: Wire refinement data flow for conversation mode

### DIFF
--- a/apps/web/src/app/(dashboard)/generate/generate-client.tsx
+++ b/apps/web/src/app/(dashboard)/generate/generate-client.tsx
@@ -114,13 +114,24 @@ function GeneratePageClient() {
     []
   );
 
-  const handleRefine = useCallback(
-    async (refinementPrompt: string) => {
-      if (!lastFormOptions) return;
-      generation.startRefinement(refinementPrompt, lastFormOptions);
-    },
-    [generation, lastFormOptions]
-  );
+  const handleRefine = async (refinementPrompt: string) => {
+    if (!lastFormOptions) return;
+    setIsGenerating(true);
+    try {
+      const result = await generation.startGeneration({
+        ...lastFormOptions,
+        parentGenerationId: generationId ?? undefined,
+        previousCode: generatedCode,
+        refinementPrompt,
+      });
+      if (result) {
+        setGeneratedCode(result.code);
+        setGenerationId(result.generationId);
+      }
+    } finally {
+      setIsGenerating(false);
+    }
+  };
 
   const handleNewGeneration = useCallback(() => {
     generation.reset();
@@ -305,7 +316,7 @@ function GeneratePageClient() {
 
       {generatedCode && !isGenerating && (
         <div className="mt-4 space-y-3">
-          {conversationEnabled && generation.parentGenerationId && (
+          {conversationEnabled && generationId && (
             <RefinementInput
               onRefine={handleRefine}
               onNewGeneration={handleNewGeneration}

--- a/apps/web/src/components/generator/GeneratorForm.tsx
+++ b/apps/web/src/components/generator/GeneratorForm.tsx
@@ -153,6 +153,7 @@ export default function GeneratorForm({
       onGenerate(generation.code, {
         ...currentSettings,
         qualityReport: generation.qualityReport,
+        generationId: generation.parentGenerationId,
         formOptions: {
           framework: framework as 'react' | 'vue' | 'angular' | 'svelte',
           componentLibrary: currentSettings.componentLibrary || 'none',
@@ -171,6 +172,7 @@ export default function GeneratorForm({
     generation.isGenerating,
     generation.error,
     generation.qualityReport,
+    generation.parentGenerationId,
     onGenerate,
     currentSettings,
     framework,

--- a/apps/web/src/hooks/use-generation.ts
+++ b/apps/web/src/hooks/use-generation.ts
@@ -64,6 +64,7 @@ export function useGeneration(_projectId?: string) {
 
         let chunkCount = 0;
         let code = '';
+        let resultGenerationId: string | null = null;
 
         for await (const event of streamGeneration(options)) {
           if (abortControllerRef.current?.signal.aborted) break;
@@ -99,6 +100,7 @@ export function useGeneration(_projectId?: string) {
               break;
 
             case 'complete':
+              resultGenerationId = event.generationId ?? null;
               setState((prev) => ({
                 ...prev,
                 code,
@@ -123,12 +125,16 @@ export function useGeneration(_projectId?: string) {
           if (prev.isGenerating) return { ...prev, isGenerating: false };
           return prev;
         });
+
+        return { code, generationId: resultGenerationId };
       } catch (error) {
         setState((prev) => ({
           ...prev,
           error: error instanceof Error ? error.message : 'Unknown error',
           isGenerating: false,
         }));
+
+        return null;
       }
     },
     []


### PR DESCRIPTION
## Summary
- **startGeneration** returns `{code, generationId}` for event-driven state sync
- **handleRefine** calls `startGeneration()` directly with page state, fixing the data flow gap
- **GeneratorForm** passes `generationId` through `onGenerate` callback
- **RefinementInput** renders based on page `generationId` instead of hook state

## Problem
Initial generation runs through GeneratorForm's hook, but refinement used the page-level hook whose `parentGenerationId` and `code` were empty — making every refinement a fresh generation instead of chaining.

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] ESLint — zero errors/warnings
- [x] Jest — 589 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)