### PR TITLE
fix: Update docs accuracy — repo count, tool count, feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Docs accuracy**: Update repo count 6→7, tool count 17→21, flag count 17→24 across all docs pages
+- **Docs feature flags**: Add 7 missing flags (conversation mode, design analysis/context, autocomplete, IntelliSense, MCP gateway, onboarding), fix `ENABLE_MULTI_LLM` default from `false` to `true`
+- **Docs architecture**: Add brand-guide to mermaid diagram and repo sections, fix Node.js version requirement
+- **Docs index**: Add brand-guide to ecosystem table
+
 ## [0.21.0] - 2026-03-01
 
 ### Added

--- a/apps/docs/content/docs/api-reference/meta.json
+++ b/apps/docs/content/docs/api-reference/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "API Reference",
+  "icon": "Code",
   "pages": ["mcp-tools", "rest-api", "webhooks"]
 }

--- a/apps/docs/content/docs/ecosystem/architecture.mdx
+++ b/apps/docs/content/docs/ecosystem/architecture.mdx
@@ -1,9 +1,9 @@
 ---
 title: Architecture
-description: The 6-repository Forge Space ecosystem
+description: The 7-repository Forge Space ecosystem
 ---
 
-Siza is built as a distributed ecosystem of six repositories, each with a clear responsibility.
+Siza is built as a distributed ecosystem of seven repositories, each with a clear responsibility.
 
 ## Repository Map
 
@@ -14,6 +14,7 @@ graph TB
     FP --> SM[siza-mcp<br/>MCP protocol adapter]
     FP --> SZ[siza<br/>Web app & API]
     FP --> BM[branding-mcp<br/>Brand generation]
+    BM --> BG[brand-guide<br/>Brand documentation site]
     SG --> SM
     MG --> SZ
     SM --> SZ
@@ -53,7 +54,7 @@ The extracted AI brain — contains all generation logic, ML composition, qualit
 
 **GitHub:** [Forge-Space/ui-mcp](https://github.com/Forge-Space/ui-mcp)
 
-Thin MCP protocol adapter (~355 KB) that exposes 17 tools to any MCP-compatible IDE. Delegates all generation logic to `@forgespace/siza-gen`.
+Thin MCP protocol adapter that exposes 21 tools to any MCP-compatible IDE. Delegates all generation logic to `@forgespace/siza-gen`.
 
 **Key features:**
 
@@ -80,6 +81,12 @@ Shared configurations, TypeScript types, security framework, and ecosystem stand
 **GitHub:** [Forge-Space/branding-mcp](https://github.com/Forge-Space/branding-mcp)
 
 MCP server specialized in brand identity generation — logos, color palettes, typography, brand guidelines, and AI-powered brand interpretation.
+
+### brand-guide (Brand Documentation)
+
+**GitHub:** [Forge-Space/brand-guide](https://github.com/Forge-Space/brand-guide)
+
+Astro-based static site documenting the Siza brand identity. Exports design tokens in CSS, W3C JSON, Tailwind, Sass, and React formats. Generated from `branding-mcp`.
 
 ## Data Flow
 

--- a/apps/docs/content/docs/ecosystem/meta.json
+++ b/apps/docs/content/docs/ecosystem/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Ecosystem",
+  "icon": "Network",
   "pages": ["architecture", "contributing"]
 }

--- a/apps/docs/content/docs/getting-started/configuration.mdx
+++ b/apps/docs/content/docs/getting-started/configuration.mdx
@@ -60,7 +60,7 @@ description: Environment variables and feature flags
 
 ## Feature Flags
 
-17 flags control features. All have sensible defaults. Override via `NEXT_PUBLIC_[FLAG_NAME]=true`.
+24 flags control features. All have sensible defaults. Override via `NEXT_PUBLIC_[FLAG_NAME]=true`.
 
 ### Authentication
 
@@ -72,10 +72,15 @@ description: Environment variables and feature flags
 
 ### Generation
 
-| Flag                          | Default | Description                     |
-| ----------------------------- | ------- | ------------------------------- |
-| `ENABLE_COMPONENT_GENERATION` | `true`  | AI-powered component generation |
-| `ENABLE_MULTI_LLM`            | `false` | Multi-provider AI selection     |
+| Flag                          | Default | Description                               |
+| ----------------------------- | ------- | ----------------------------------------- |
+| `ENABLE_COMPONENT_GENERATION` | `true`  | AI-powered component generation           |
+| `ENABLE_MULTI_LLM`            | `true`  | Multi-provider AI selection               |
+| `ENABLE_CONVERSATION_MODE`    | `true`  | Multi-turn conversation for AI generation |
+| `ENABLE_DESIGN_ANALYSIS`      | `true`  | Design analysis panel in generator        |
+| `ENABLE_DESIGN_CONTEXT`       | `true`  | Design context for generation             |
+| `ENABLE_PROMPT_AUTOCOMPLETE`  | `true`  | Autocomplete suggestions in prompt input  |
+| `ENABLE_CODE_INTELLISENSE`    | `true`  | IntelliSense in code editor               |
 
 ### Integrations
 
@@ -88,16 +93,18 @@ description: Environment variables and feature flags
 
 ### System
 
-| Flag                               | Default | Description                         |
-| ---------------------------------- | ------- | ----------------------------------- |
-| `ENABLE_REALTIME_UPDATES`          | `true`  | Supabase Realtime                   |
-| `ENABLE_DARK_MODE`                 | `true`  | Dark mode toggle                    |
-| `ENABLE_ANALYTICS`                 | `false` | Usage analytics tracking            |
-| `ENABLE_MAINTENANCE_MODE`          | `false` | Block all access                    |
-| `ENABLE_BETA_FEATURES`             | `false` | Experimental features               |
-| `ENABLE_QUALITY_GATES`             | `false` | Quality checks before PR creation   |
-| `ENABLE_CENTRALIZED_FEATURE_FLAGS` | `false` | Database-backed flags (vs env vars) |
-| `ENABLE_PROJECT_THUMBNAILS`        | `true`  | Project thumbnail uploads           |
+| Flag                               | Default | Description                          |
+| ---------------------------------- | ------- | ------------------------------------ |
+| `ENABLE_REALTIME_UPDATES`          | `true`  | Supabase Realtime                    |
+| `ENABLE_DARK_MODE`                 | `true`  | Dark mode toggle                     |
+| `ENABLE_ANALYTICS`                 | `false` | Usage analytics tracking             |
+| `ENABLE_MAINTENANCE_MODE`          | `false` | Block all access                     |
+| `ENABLE_BETA_FEATURES`             | `false` | Experimental features                |
+| `ENABLE_QUALITY_GATES`             | `false` | Quality checks before PR creation    |
+| `ENABLE_CENTRALIZED_FEATURE_FLAGS` | `false` | Database-backed flags (vs env vars)  |
+| `ENABLE_MCP_GATEWAY`               | `false` | Route generation through mcp-gateway |
+| `ENABLE_ONBOARDING`                | `false` | Post-signup onboarding wizard        |
+| `ENABLE_PROJECT_THUMBNAILS`        | `true`  | Project thumbnail uploads            |
 
 ## Pricing Plans
 

--- a/apps/docs/content/docs/getting-started/meta.json
+++ b/apps/docs/content/docs/getting-started/meta.json
@@ -1,4 +1,5 @@
 {
   "title": "Getting Started",
+  "icon": "Rocket",
   "pages": ["quick-start", "installation", "configuration", "self-hosting", "deployment"]
 }

--- a/apps/docs/content/docs/getting-started/self-hosting.mdx
+++ b/apps/docs/content/docs/getting-started/self-hosting.mdx
@@ -7,7 +7,7 @@ Siza is fully self-hostable. Bring your own API keys (BYOK) and deploy to Cloudf
 
 ## Prerequisites
 
-- Node.js 22+
+- Node.js 20+
 - A [Supabase](https://supabase.com) project (free tier works)
 - A [Google AI Studio](https://aistudio.google.com/apikey) API key (Gemini, free tier available)
 
@@ -84,7 +84,7 @@ npx wrangler secret put GEMINI_API_KEY
 
 ## Feature flags
 
-17 feature flags control what's enabled. All default to sensible values. Override via environment variables:
+24 feature flags control what's enabled. All default to sensible values. Override via environment variables:
 
 ```bash
 NEXT_PUBLIC_ENABLE_STRIPE_BILLING=true

--- a/apps/docs/content/docs/guides/mcp-integration.mdx
+++ b/apps/docs/content/docs/guides/mcp-integration.mdx
@@ -3,7 +3,7 @@ title: MCP Integration
 description: Connect siza-mcp to your IDE
 ---
 
-Siza's MCP server exposes 17 AI generation tools to any IDE that supports the [Model Context Protocol](https://modelcontextprotocol.io/).
+Siza's MCP server exposes 21 AI generation tools to any IDE that supports the [Model Context Protocol](https://modelcontextprotocol.io).
 
 ## Install
 

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Guides",
+  "icon": "BookOpen",
   "pages": [
     "first-component",
     "components",

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -9,7 +9,7 @@ Named after [Álvaro Siza Vieira](https://en.wikipedia.org/wiki/%C3%81lvaro_Siza
 
 ## What is Siza?
 
-An open-source AI workspace that connects AI models to your development workflow through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/):
+An open-source AI workspace that connects AI models to your development workflow through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io):
 
 - **Web App** — generate components, manage projects, preview live, export to GitHub
 - **MCP Server** — integrate AI generation directly into Claude Desktop, Cursor, or any MCP-compatible IDE
@@ -17,20 +17,21 @@ An open-source AI workspace that connects AI models to your development workflow
 
 ## Architecture
 
-Six repositories power the ecosystem:
+Seven repositories power the ecosystem:
 
 | Repository         | Purpose                                              |
 | ------------------ | ---------------------------------------------------- |
 | **siza**           | Next.js web app + Cloudflare Workers API             |
-| **siza-mcp**       | MCP server with 17 AI generation tools               |
+| **siza-mcp**       | MCP server with 21 AI generation tools               |
 | **mcp-gateway**    | Multi-provider AI routing (Gemini, Claude, GPT)      |
 | **forge-patterns** | Shared configs, types, and security framework        |
 | **siza-gen**       | AI generation core library (extracted from siza-mcp) |
 | **branding-mcp**   | Brand identity generation tools                      |
+| **brand-guide**    | Astro-based brand identity documentation site        |
 
 ## Quick links
 
 - [Quick Start](/docs/getting-started/quick-start) — zero to first component in 5 minutes
 - [Self-Hosting](/docs/getting-started/self-hosting) — BYOK deployment guide
 - [MCP Integration](/docs/guides/mcp-integration) — connect siza-mcp to your IDE
-- [Architecture](/docs/ecosystem/architecture) — how the 6 repos connect
+- [Architecture](/docs/ecosystem/architecture) — how the 7 repos connect

--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -2,6 +2,7 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 import Image from 'next/image';
 
 export const baseOptions: BaseLayoutProps = {
+  themeSwitch: { enabled: false },
   nav: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,7 +1,9 @@
 import { docs } from '@/../.source/server';
 import { loader } from 'fumadocs-core/source';
+import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
+  plugins: [lucideIconsPlugin()],
 });


### PR DESCRIPTION
## Summary
- Update ecosystem docs from 6→7 repos (add brand-guide)
- Update siza-mcp tool count 17→21
- Update feature flag count 17→24 with 7 missing flags added
- Fix `ENABLE_MULTI_LLM` default from `false` to `true`
- Add brand-guide to architecture mermaid diagram and repo sections
- Fix Node.js version requirement (22→20) in self-hosting docs
- Add Lucide sidebar icons and disable theme toggle (dark-only)

## Test plan
- [x] `npm run lint` — all 6 tasks pass
- [x] `npm run type-check` — all 5 tasks pass (docs type-check clean)
- [x] `npm run test` — 608 tests pass
- [x] Prettier check on all MDX files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)