### PR TITLE
fix: Update interactive docs — tool count, add brand-guide

### DIFF
--- a/apps/docs/content/docs/ecosystem/contributing.mdx
+++ b/apps/docs/content/docs/ecosystem/contributing.mdx
@@ -146,7 +146,7 @@ npm run type-check  # TypeScript checking
   />
   <ContribRepo
     name="siza-mcp"
-    desc="MCP protocol adapter — 17 tools for any IDE, RAG-based design matching."
+    desc="MCP protocol adapter — 21 tools for any IDE, RAG-based design matching."
     lang="TypeScript"
     langColor="#34d399"
     tags={['MCP', 'SQLite', 'Jest ESM']}
@@ -175,6 +175,14 @@ npm run type-check  # TypeScript checking
     langColor="#fb923c"
     tags={['MCP', 'Design', 'Brand']}
     url="https://github.com/Forge-Space/branding-mcp"
+  />
+  <ContribRepo
+    name="brand-guide"
+    desc="Astro-based brand identity documentation site with design token exports."
+    lang="Astro"
+    langColor="#e879f9"
+    tags={['Astro', 'Tailwind', 'Design Tokens']}
+    url="https://github.com/Forge-Space/brand-guide"
   />
 </ContribRepos>
 

--- a/apps/docs/src/components/ArchitectureDiagram.tsx
+++ b/apps/docs/src/components/ArchitectureDiagram.tsx
@@ -55,9 +55,19 @@ const repos: RepoNode[] = [
     deps: ['forge-patterns'],
   },
   {
+    id: 'brand-guide',
+    name: 'brand-guide',
+    desc: 'Brand identity documentation site',
+    icon: <IconBook />,
+    badges: ['Astro', 'Tailwind', 'Design Tokens'],
+    accent: '#e879f9',
+    github: 'https://github.com/Forge-Space/brand-guide',
+    deps: ['branding-mcp'],
+  },
+  {
     id: 'siza-mcp',
     name: 'siza-mcp',
-    desc: 'MCP protocol adapter — 17 tools for IDEs',
+    desc: 'MCP protocol adapter — 21 tools for IDEs',
     icon: <IconPlug />,
     badges: ['TypeScript', 'MCP', 'SQLite'],
     accent: '#34d399',
@@ -79,7 +89,7 @@ const repos: RepoNode[] = [
 const tiers = [
   { label: 'Foundation', ids: ['forge-patterns'] },
   { label: 'Services', ids: ['mcp-gateway', 'siza-gen', 'branding-mcp'] },
-  { label: 'Integration', ids: ['siza-mcp', 'siza'] },
+  { label: 'Integration', ids: ['siza-mcp', 'brand-guide', 'siza'] },
 ];
 
 export function ArchitectureDiagram() {
@@ -268,6 +278,21 @@ function IconPlug() {
       <path d="M9 8V2" />
       <path d="M15 8V2" />
       <path d="M18 8v5a6 6 0 0 1-6 6v0a6 6 0 0 1-6-6V8Z" />
+    </svg>
+  );
+}
+
+function IconBook() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />
     </svg>
   );
 }

--- a/apps/docs/src/components/ContributingGuide.tsx
+++ b/apps/docs/src/components/ContributingGuide.tsx
@@ -33,7 +33,7 @@ export function ContribHero() {
           <span className="contrib-stat-label">Tests passing</span>
         </div>
         <div className="contrib-stat">
-          <span className="contrib-stat-value">22</span>
+          <span className="contrib-stat-value">21</span>
           <span className="contrib-stat-label">MCP Tools</span>
         </div>
         <div className="contrib-stat">


### PR DESCRIPTION
## Summary

Follow-up to PR #234 (Interactive docs) — fixes content accuracy issues:

- Fix MCP tool count: 17 → 21 in `ArchitectureDiagram` component and contributing MDX
- Fix MCP Tools stat: 22 → 21 in `ContribHero` component
- Add `brand-guide` repo to interactive architecture diagram (7th repo was missing)
- Add `brand-guide` to contributing repos list
- Add `IconBook` SVG icon for brand-guide card

## Test plan

- [x] `npm run type-check` — all 5 packages pass
- [x] `npm run lint` — all 6 packages pass
- [ ] CI passes (lint, type-check, build, tests, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP protocol adapter information reflecting expanded toolset capabilities.
  * Added new brand-guide repository to the ecosystem documentation with design-token focus.
  * Refreshed contributing guide statistics for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->