### PR TITLE
fix: Unblock Monaco editor and Supabase realtime in CSP

### DIFF
--- a/apps/web/src/__tests__/lib/security/headers.test.ts
+++ b/apps/web/src/__tests__/lib/security/headers.test.ts
@@ -27,14 +27,29 @@ describe('securityHeaders', () => {
     expect(headers['Content-Security-Policy']).toContain('https://js.stripe.com');
   });
 
-  it('CSP allows Supabase connections', () => {
+  it('CSP allows Monaco Editor CDN', () => {
     const headers = securityHeaders();
-    expect(headers['Content-Security-Policy']).toContain('https://*.supabase.co');
+    const csp = headers['Content-Security-Policy'];
+    expect(csp).toContain('https://cdn.jsdelivr.net');
+    expect(csp).toMatch(/script-src[^;]*https:\/\/cdn\.jsdelivr\.net/);
+    expect(csp).toMatch(/style-src[^;]*https:\/\/cdn\.jsdelivr\.net/);
+  });
+
+  it('CSP allows Supabase connections including WebSocket', () => {
+    const headers = securityHeaders();
+    const csp = headers['Content-Security-Policy'];
+    expect(csp).toContain('https://*.supabase.co');
+    expect(csp).toContain('wss://*.supabase.co');
   });
 
   it('CSP allows Sentry connections', () => {
     const headers = securityHeaders();
     expect(headers['Content-Security-Policy']).toContain('https://*.sentry.io');
+  });
+
+  it('CSP allows blob: workers for Monaco', () => {
+    const headers = securityHeaders();
+    expect(headers['Content-Security-Policy']).toContain("worker-src 'self' blob:");
   });
 
   it('CSP denies frame-ancestors', () => {

--- a/apps/web/src/lib/security/headers.ts
+++ b/apps/web/src/lib/security/headers.ts
@@ -1,6 +1,7 @@
 const ALLOWED_CONNECT_DOMAINS = [
   "'self'",
   'https://*.supabase.co',
+  'wss://*.supabase.co',
   'https://*.sentry.io',
   'https://ingest.sentry.io',
   'https://js.stripe.com',
@@ -10,11 +11,12 @@ const ALLOWED_CONNECT_DOMAINS = [
 function buildCSP(): string {
   const directives = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' https://js.stripe.com",
-    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' https://js.stripe.com https://cdn.jsdelivr.net",
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
     "img-src 'self' data: blob: https://*.supabase.co",
-    "font-src 'self' data:",
+    "font-src 'self' data: https://cdn.jsdelivr.net",
     'connect-src ' + ALLOWED_CONNECT_DOMAINS.join(' '),
+    "worker-src 'self' blob:",
     "frame-src 'self' https://js.stripe.com",
     "frame-ancestors 'none'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary
- Add `cdn.jsdelivr.net` to `script-src`, `style-src`, and `font-src` (Monaco Editor CDN)
- Add `wss://*.supabase.co` to `connect-src` (Supabase Realtime WebSocket)
- Add `worker-src 'self' blob:` directive (Monaco Web Workers)

## Problem
The code editor and live preview on the generate page were completely broken in production. CSP blocked:
1. Monaco Editor script loading from jsdelivr CDN
2. Supabase Realtime WebSocket connections (`wss://` scheme not covered by `https://` rule)
3. Monaco Web Worker blobs

## Test plan
- [x] Unit tests updated and passing (10/10)
- [ ] Deploy and verify Monaco editor loads on `/generate`
- [ ] Verify Supabase realtime connections work (no CSP errors in console)
- [ ] Verify live preview renders generated components

🤖 Generated with [Claude Code](https://claude.com/claude-code)