### PR TITLE
fix: Siza AI provider — needsApiKey blocks generation + a11y

### DIFF
--- a/apps/web/src/components/generator/BYOKProviderGrid.tsx
+++ b/apps/web/src/components/generator/BYOKProviderGrid.tsx
@@ -30,6 +30,7 @@ export function BYOKProviderGrid({
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
         className="w-full flex items-center justify-between p-3 text-sm text-text-secondary hover:text-text-primary"
       >
         <span>Advanced: Use Your Own Key</span>

--- a/apps/web/src/components/generator/GeneratorForm.tsx
+++ b/apps/web/src/components/generator/GeneratorForm.tsx
@@ -122,7 +122,7 @@ export default function GeneratorForm({
     if (initialDescription) setValue('prompt', initialDescription);
   }, [initialDescription, setValue]);
 
-  const needsApiKey = selectedProvider !== 'google' && !providerKey;
+  const needsApiKey = selectedProvider !== 'google' && selectedProvider !== 'siza' && !providerKey;
 
   const onSubmit = async (data: GeneratorFormData) => {
     try {

--- a/apps/web/src/components/generator/SizaAICard.tsx
+++ b/apps/web/src/components/generator/SizaAICard.tsx
@@ -23,6 +23,7 @@ export function SizaAICard({
     <button
       type="button"
       onClick={onSelect}
+      aria-pressed={selected}
       className={cn(
         'w-full rounded-lg border p-4 text-left transition-all',
         selected


### PR DESCRIPTION
## Summary

- **Critical fix**: `needsApiKey` check excluded only `google` from requiring a BYOK key. Since v0.23.0 defaults to `siza` provider (server-side routing, no API key needed), the generate button was disabled for all users without a stored siza key
- **Accessibility**: Added `aria-pressed` to SizaAICard and `aria-expanded` to BYOKProviderGrid disclosure

## Changes

- `GeneratorForm.tsx`: Exclude `siza` from BYOK key requirement (`needsApiKey` check)
- `SizaAICard.tsx`: Add `aria-pressed={selected}` for screen readers
- `BYOKProviderGrid.tsx`: Add `aria-expanded={expanded}` for assistive tech

## Test plan
- [x] 610 tests pass locally (48 suites)
- [ ] Verify generate button is enabled when Siza AI is selected (no BYOK key required)
- [ ] Verify BYOK providers still require API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)