### PR TITLE
chore: Release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-03-01
+
+### Fixed
+- **Siza AI generate button blocked**: Excluded `siza` provider from BYOK key requirement — generate button was disabled for all users without a stored key
+- **Accessibility**: Added `aria-pressed` to SizaAICard, `aria-expanded` to BYOKProviderGrid disclosure
+
 ## [0.23.0] - 2026-03-01
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siza-webapp",
-  "version": "0.22.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siza-webapp",
-      "version": "0.22.0",
+      "version": "0.23.1",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -485,7 +485,7 @@
     },
     "apps/web": {
       "name": "@siza/web",
-      "version": "0.22.0",
+      "version": "0.23.1",
       "hasInstallScript": true,
       "dependencies": {
         "@google/generative-ai": "^0.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
- Hotfix release for v0.23.0 — Siza AI generate button was blocked because `needsApiKey` didn't exclude the `siza` provider
- Version bump to 0.23.1 (root + apps/web)
- CHANGELOG entry for PR #248 fix + a11y improvements

## Test plan
- [x] PR #248 already merged and CI-verified (12/12 checks pass)
- [ ] Release automation creates v0.23.1 tag on merge
- [ ] Deploy triggers to Cloudflare Workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)