### PR TITLE
feat: Add BYOK context injection with siza-gen assembler

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@forgespace/brand-guide": "^0.3.1",
+    "@forgespace/siza-gen": "^0.7.0",
     "@google/generative-ai": "^0.24.1",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -14,7 +14,7 @@ import {
   createGenerationRecord,
   completeGeneration,
   failGeneration,
-  runQualityGates,
+  runEnhancedGates,
   postGenerationTasks,
   createSseEvent,
   buildStreamPrompt,
@@ -128,6 +128,9 @@ export async function POST(request: NextRequest) {
             imageMimeType: input.imageMimeType,
             provider: input.provider,
             model: input.model || 'gemini-2.0-flash',
+            componentType: input.componentType,
+            mood: input.mood,
+            industry: input.industry,
           })) {
             if (event.type === 'chunk' && event.content) {
               fullCode += event.content;
@@ -145,7 +148,11 @@ export async function POST(request: NextRequest) {
             controller.enqueue(encoder.encode(createSseEvent(event)));
           }
 
-          const qualityReport = runQualityGates(fullCode);
+          const qualityReport = await runEnhancedGates(
+            fullCode,
+            input.description,
+            input.framework
+          );
           controller.enqueue(
             encoder.encode(
               createSseEvent({

--- a/apps/web/src/lib/api/validation/generate.ts
+++ b/apps/web/src/lib/api/validation/generate.ts
@@ -35,6 +35,37 @@ export const generateSchema = z.object({
       info: z.string().regex(hexColorRegex),
     })
     .optional(),
+  componentType: z.string().max(50).optional(),
+  mood: z
+    .enum([
+      'professional',
+      'playful',
+      'elegant',
+      'bold',
+      'minimal',
+      'warm',
+      'cool',
+      'futuristic',
+      'organic',
+      'corporate',
+      'creative',
+      'technical',
+    ])
+    .optional(),
+  industry: z
+    .enum([
+      'saas',
+      'ecommerce',
+      'fintech',
+      'healthcare',
+      'education',
+      'media',
+      'social',
+      'enterprise',
+      'startup',
+      'agency',
+    ])
+    .optional(),
   parentGenerationId: z.string().uuid().optional(),
   previousCode: z.string().max(50000).optional(),
   refinementPrompt: z.string().min(3).max(1000).optional(),

--- a/apps/web/src/lib/services/generation.service.ts
+++ b/apps/web/src/lib/services/generation.service.ts
@@ -1,7 +1,12 @@
 import { createGeneration, updateGeneration } from '@/lib/repositories/generation.repo';
 import { enrichPromptWithContext } from './context-enrichment';
 import { storeGenerationEmbedding } from './embeddings';
-import { runAllGates, type QualityReport } from '@/lib/quality/gates';
+import {
+  runAllGates,
+  runEnhancedGates,
+  type QualityReport,
+  type EnhancedQualityReport,
+} from '@/lib/quality/gates';
 import { incrementGenerationCount } from '@/lib/usage/tracker';
 
 const BORDER_RADIUS_MAP: Record<string, string> = {
@@ -138,6 +143,8 @@ export async function failGeneration(generationId: string, errorMessage: string)
 export function runQualityGates(code: string): QualityReport {
   return runAllGates(code);
 }
+
+export { runEnhancedGates, type EnhancedQualityReport };
 
 export async function postGenerationTasks(
   generationId: string,

--- a/apps/web/src/lib/services/provider-router.ts
+++ b/apps/web/src/lib/services/provider-router.ts
@@ -20,6 +20,9 @@ export interface RouteGenerationOptions {
   imageMimeType?: string;
   provider: string;
   model: string;
+  componentType?: string;
+  mood?: string;
+  industry?: string;
 }
 
 export async function* routeGeneration(


### PR DESCRIPTION
## Summary

- Replace generic 6-line system prompt with budget-aware prompt composer from `@forgespace/siza-gen@0.7.0`
- BYOK calls now carry ~4K tokens of curated expertise: anti-generic rules, framework conventions, a11y guidelines, and few-shot examples from the 502-snippet registry
- Enhanced quality gates: 70% existing 5-gate system + 30% siza-gen heuristic scoring blend

## Changes

- `generation.ts`: Dynamic `getEnrichedSystemPrompt()` using `assembleContext()` with try/catch fallback
- `validation/generate.ts`: Add `componentType`, `mood` (12 values), `industry` (10 values) fields
- `gates.ts`: Add `runEnhancedGates()` with blended quality scoring
- `provider-router.ts`: Pass new fields through routing pipeline
- `route.ts`: Wire enhanced gates and new fields into generation flow
- `generation.service.ts`: Re-export enhanced gates types
- `package.json`: Add `@forgespace/siza-gen@^0.7.0` dependency

## Design decisions

- **Dynamic require()** with try/catch: Zero regression risk — if siza-gen isn't available, falls back to the original static prompt
- **Token budget**: 4K tokens (~2% of GPT-4o's 128K context), negligible overhead
- **Blended scoring**: Security gates weighted 70% (critical), heuristic 30% (code quality enrichment)

## Test plan

- [x] siza-gen v0.7.0 published to npm (441 tests, 22 suites)
- [ ] CI: Build, Lint, TypeCheck, Unit Tests pass
- [ ] Manual: Generate with BYOK (OpenAI/Anthropic) — verify rich system prompt
- [ ] Manual: Generate with Siza AI — verify fallback still works
- [ ] Quality scores reflect blended heuristic factors

Generated with [Claude Code](https://claude.com/claude-code)