### PR TITLE
docs: Add security vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,174 +1,63 @@
-# Siza Security Configuration
+# Security Policy
 
-This document outlines the security measures and configurations implemented for the Siza project.
+This policy covers [Siza](https://github.com/Forge-Space/siza), the full-stack AI workspace. For general Forge Space security policy, see the [organization-level policy](https://github.com/Forge-Space/.github/blob/main/SECURITY.md).
 
-## 🔐 Security Overview
+## Reporting a Vulnerability
 
-### Current Security Status
-- ✅ **Zero vulnerabilities** detected in dependency scanning
-- ✅ **Zero code security issues** found
-- ✅ **Snyk monitoring** configured and active
-- ✅ **Automated security scanning** in CI/CD
+### Preferred: GitHub Private Security Advisory
 
-## 🛡️ Implemented Security Measures
+Open a [Private Security Advisory](https://github.com/Forge-Space/siza/security/advisories/new) directly on this repository.
 
-### 1. Dependency Security
-- **Snyk SCA Scanning**: Continuous monitoring of all npm dependencies
-- **Vulnerability Remediation**: Automatic updates for security patches
-- **Next.js Upgrade**: Upgraded from 15.5.12 to 16.1.5 to fix CVE-2025-59472
+### Alternative: Email
 
-### 2. Code Security
-- **X-Powered-By Header**: Disabled in Express API to prevent information disclosure
-- **Hardcoded Passwords**: Eliminated hardcoded passwords in test files
-- **Random Password Generation**: Using crypto.randomBytes for test credentials
+Send details to [security@forgespace.co](mailto:security@forgespace.co).
 
-### 3. Infrastructure Security
-- **Docker Security**: Multi-stage builds with non-root user
-- **Node.js Base Images**: Using official slim images with security patches
-- **Health Checks**: Container health monitoring
+Include:
 
-### 4. Application Security
-- **CORS Configuration**: Properly configured cross-origin resource sharing
-- **Input Validation**: Zod schemas for API request validation
-- **Rate Limiting**: API rate limiting to prevent abuse
-- **Environment Variables**: Secure handling of sensitive configuration
+- Description of the vulnerability
+- Steps to reproduce
+- Affected version or deployment
+- Potential impact assessment
 
-## 🔧 Security Tools Configuration
+## Response Timeline
 
-### Snyk Integration
-- **Authentication**: Configured with Snyk account
-- **Project Monitoring**: Continuous monitoring enabled
-- **Severity Threshold**: High and above issues trigger alerts
-- **CI/CD Integration**: GitHub Actions workflow for automated scanning
+| Stage | Target |
+|-------|--------|
+| Acknowledgment | < 48 hours |
+| Triage and severity assessment | < 7 days |
+| Fix for critical severity | < 7 days |
+| Fix for high severity | < 30 days |
+| Fix for medium/low severity | Next release cycle |
 
-### GitHub Actions Security Workflow
-```yaml
-# File: .github/workflows/snyk-security.yml
-- Triggers: Push to main/develop, PRs, daily schedule
-- Scans: Both API and Web applications
-- Reporting: SARIF upload to GitHub Security tab
-- Notifications: Configured for new vulnerabilities
-```
+## Scope
 
-## 📊 Security Scan Results
+### In Scope
 
-### Latest Scan Results
-- **Dependencies**: 0 vulnerabilities
-- **Code Issues**: 0 security issues
-- **Severity Breakdown**:
-  - Critical: 0
-  - High: 0
-  - Medium: 0
-  - Low: 0
+- Authentication flows (Supabase Auth, OAuth providers, session management)
+- Stripe billing integration (webhooks, checkout, customer portal)
+- API routes and server-side data handling
+- CORS and CSP configuration
+- User data storage and access control (Supabase RLS policies)
+- Input validation and sanitization
+- BYOK (Bring Your Own Key) encryption and key storage
+- File upload handling and storage bucket permissions
 
-### Historical Issues Fixed
-1. **CVE-2025-59472**: Next.js allocation of resources without limits
-   - **Fixed**: Upgraded Next.js to 16.1.5
-   - **Impact**: Prevented potential DoS attacks
+### Out of Scope
 
-2. **Information Disclosure**: X-Powered-By header
-   - **Fixed**: Disabled header in Express server
-   - **Impact**: Reduced attack surface
+- Third-party service vulnerabilities (Supabase, Stripe, Cloudflare) -- report upstream
+- Client-side UI rendering issues without security impact
+- Rate limiting thresholds (by design, not a vulnerability)
+- Issues only reproducible in development mode
 
-3. **Hardcoded Passwords**: Test credentials
-   - **Fixed**: Implemented random password generation
-   - **Impact**: Improved test security
+## Supported Versions
 
-## 🚀 Security Best Practices Implemented
+Only the latest production deployment is supported. Siza uses continuous deployment to Cloudflare Workers -- there are no maintained older versions.
 
-### Development Practices
-- **Code Reviews**: Security-focused review process
-- **Dependency Updates**: Regular security patch updates
-- **Secret Management**: Environment variables for sensitive data
-- **Test Security**: No hardcoded credentials in tests
+## Safe Harbor
 
-### Operational Security
-- **Container Security**: Non-root users, minimal base images
-- **Network Security**: Proper CORS and rate limiting
-- **Monitoring**: Continuous vulnerability scanning
-- **Incident Response**: Automated alerts for security issues
+We support safe harbor for security researchers acting in good faith. See the [organization-level policy](https://github.com/Forge-Space/.github/blob/main/SECURITY.md) for full safe harbor terms.
 
-## 🔄 Ongoing Security Maintenance
+## Contact
 
-### Daily Automated Tasks
-- Snyk dependency scanning
-- Container vulnerability checks
-- Security code analysis
-
-### Weekly Tasks
-- Review security advisories
-- Update dependencies if needed
-- Monitor security alerts
-
-### Monthly Tasks
-- Comprehensive security audit
-- Update security configurations
-- Review and update security policies
-
-## 📞 Security Contacts
-
-- **Security Team**: [security@forgespace.co](mailto:security@forgespace.co)
-- **Vulnerability Reporting**: [security@forgespace.co](mailto:security@forgespace.co)
-- **Snyk Organization**: Configured in Snyk dashboard
-
-## 🛠️ Security Commands
-
-### Manual Security Scans
-```bash
-# Scan all dependencies
-snyk test --all-projects
-
-# Scan code for security issues
-snyk code test
-
-# Scan Docker images
-snyk container test node:22.22.0-trixie-slim
-
-# Monitor project continuously
-snyk monitor --all-projects
-```
-
-### Local Development
-```bash
-# Trust directory for Snyk
-snyk trust
-
-# Run comprehensive security check
-npm audit
-snyk test --severity-threshold=medium
-```
-
-## 📋 Security Checklist
-
-### Pre-Deployment
-- [ ] Run Snyk dependency scan
-- [ ] Run Snyk code scan
-- [ ] Check for hardcoded secrets
-- [ ] Verify environment variables
-- [ ] Test authentication flows
-
-### Post-Deployment
-- [ ] Monitor security alerts
-- [ ] Check scan results
-- [ ] Review access logs
-- [ ] Validate rate limiting
-
-## 🔒 Security Policies
-
-### Acceptable Risk
-- **Low**: Informational issues, documented
-- **Medium**: Addressed within 7 days
-- **High**: Addressed within 24 hours
-- **Critical**: Addressed immediately
-
-### Vulnerability Response
-1. **Detection**: Automated scanning identifies issue
-2. **Assessment**: Security team evaluates impact
-3. **Remediation**: Fix implemented and tested
-4. **Deployment**: Patch deployed to production
-5. **Verification**: Post-deployment security scan
-
----
-
-*Last Updated: 2025-02-17*
-*Security Status: ✅ All Clear*
+- **Email**: [security@forgespace.co](mailto:security@forgespace.co)
+- **GitHub**: [Open a Private Security Advisory](https://github.com/Forge-Space/siza/security/advisories/new)


### PR DESCRIPTION
## Summary

- Replace internal security config doc with proper vulnerability disclosure policy
- Standardize on `security@forgespace.co` and GitHub Private Security Advisories
- Cover Siza-specific scope: Supabase auth, Stripe billing, BYOK encryption, RLS policies, CORS/CSP
- Reference org-level default policy in Forge-Space/.github

## Test plan

- [ ] Verify policy visible at github.com/Forge-Space/siza/security/policy
- [ ] Confirm `security@forgespace.co` email is consistent
- [ ] No emojis in the policy file