### PR TITLE
fix: Migrate E2E specs to fixtures pattern with Supabase admin API

### DIFF
--- a/apps/web/e2e/generation.spec.ts
+++ b/apps/web/e2e/generation.spec.ts
@@ -1,19 +1,16 @@
-import { test, expect } from '@playwright/test';
-import { setupAuthenticatedUser, cleanupTestData } from './helpers/auth';
+import { test, expect } from './fixtures';
 
 test.describe('Component Generation', () => {
+  test.skip(!process.env.SUPABASE_SERVICE_ROLE_KEY, 'Requires SUPABASE_SERVICE_ROLE_KEY');
+
   let projectId: string;
 
-  test.beforeEach(async ({ page }) => {
-    await setupAuthenticatedUser(page);
-
-    // Create a test project for generation
+  test.beforeEach(async ({ authenticatedPage: page }) => {
     await page.goto('/projects/new');
     await page.getByLabel('Project Name *').fill('Generation Test Project');
     await page.getByLabel('Framework *').selectOption('react');
     await page.getByRole('button', { name: 'Create Project' }).click();
 
-    // Extract project ID from URL
     const url = page.url();
     const match = url.match(/\/projects\/([a-f0-9-]+)/);
     if (match) {
@@ -21,11 +18,9 @@ test.describe('Component Generation', () => {
     }
   });
 
-  test.afterEach(async () => {
-    await cleanupTestData();
-  });
-
-  test('should display generation page with project context', async ({ page }) => {
+  test('should display generation page with project context', async ({
+    authenticatedPage: page,
+  }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Check page title
@@ -38,7 +33,7 @@ test.describe('Component Generation', () => {
     await expect(page.getByText('Live Preview')).toBeVisible();
   });
 
-  test('should show error when no project is selected', async ({ page }) => {
+  test('should show error when no project is selected', async ({ authenticatedPage: page }) => {
     await page.goto('/generate');
 
     // Should show error message
@@ -46,7 +41,7 @@ test.describe('Component Generation', () => {
     await expect(page.getByText(/select a project/i)).toBeVisible();
   });
 
-  test('should generate a component', async ({ page }) => {
+  test('should generate a component', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Fill out generation form
@@ -77,7 +72,7 @@ test.describe('Component Generation', () => {
     await expect(page.locator('text=/TestButton/')).toBeVisible();
   });
 
-  test('should validate component name format', async ({ page }) => {
+  test('should validate component name format', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Try invalid component names
@@ -99,7 +94,7 @@ test.describe('Component Generation', () => {
     }
   });
 
-  test('should validate prompt length', async ({ page }) => {
+  test('should validate prompt length', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     await page.getByLabel('Component Name *').fill('ValidName');
@@ -111,7 +106,7 @@ test.describe('Component Generation', () => {
     await expect(page.getByText(/at least.*characters/i)).toBeVisible();
   });
 
-  test('should copy generated code', async ({ page }) => {
+  test('should copy generated code', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Generate a component first
@@ -130,7 +125,7 @@ test.describe('Component Generation', () => {
     await expect(page.getByText('Copied')).toBeVisible();
   });
 
-  test('should download generated code', async ({ page }) => {
+  test('should download generated code', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Generate a component first
@@ -154,7 +149,7 @@ test.describe('Component Generation', () => {
     expect(download.suggestedFilename()).toMatch(/\.tsx?$/);
   });
 
-  test('should handle generation with tests option', async ({ page }) => {
+  test('should handle generation with tests option', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     await page.getByLabel('Component Name *').fill('TestWithTests');
@@ -172,7 +167,7 @@ test.describe('Component Generation', () => {
     await expect(page.locator('text=/describe|it|test|expect/')).toBeVisible();
   });
 
-  test('should handle rate limiting', async ({ page }) => {
+  test('should handle rate limiting', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Make multiple rapid requests
@@ -193,7 +188,7 @@ test.describe('Component Generation', () => {
     ).toBeVisible({ timeout: 10000 });
   });
 
-  test('should edit generated code in Monaco editor', async ({ page }) => {
+  test('should edit generated code in Monaco editor', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Generate a component
@@ -215,7 +210,7 @@ test.describe('Component Generation', () => {
     }
   });
 
-  test('should refresh live preview', async ({ page }) => {
+  test('should refresh live preview', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Generate a component
@@ -234,7 +229,7 @@ test.describe('Component Generation', () => {
     await expect(refreshButton).toBeEnabled({ timeout: 2000 });
   });
 
-  test('should show tips section', async ({ page }) => {
+  test('should show tips section', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=${projectId}&framework=react`);
 
     // Check tips are visible
@@ -243,7 +238,7 @@ test.describe('Component Generation', () => {
     await expect(page.getByText(/mention any props/i)).toBeVisible();
   });
 
-  test('should handle generation errors gracefully', async ({ page }) => {
+  test('should handle generation errors gracefully', async ({ authenticatedPage: page }) => {
     await page.goto(`/generate?projectId=invalid-uuid&framework=react`);
 
     await page.getByLabel('Component Name *').fill('ErrorTest');

--- a/apps/web/e2e/helpers/auth.ts
+++ b/apps/web/e2e/helpers/auth.ts
@@ -1,83 +1,73 @@
 import { Page } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
 
-/**
- * Sets up an authenticated user session for E2E tests
- * This is a mock implementation - in production, you'd use actual Supabase auth
- */
-export async function setupAuthenticatedUser(page: Page): Promise<void> {
-  // Navigate to signin page
-  await page.goto('/signin');
+export async function setupAuthenticatedUser(page: Page): Promise<{
+  email: string;
+  password: string;
+  id: string;
+}> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-  // For now, we'll use test credentials with a random password
-  // In production, you'd want to use Supabase test helpers
-  const testEmail = 'test@siza.dev';
-  const testPassword = crypto.randomBytes(16).toString('hex');
-
-  // Fill in credentials
-  await page.getByLabel(/email/i).fill(testEmail);
-  await page.getByLabel(/password/i).fill(testPassword);
-
-  // Submit form
-  await page.getByRole('button', { name: /sign in/i }).click();
-
-  // Wait for redirect to dashboard
-  await page.waitForURL(/\/dashboard|\/projects/, { timeout: 10000 });
-}
-
-/**
- * Cleans up test data after tests
- * This should remove any projects, generations, etc. created during tests
- */
-export async function cleanupTestData(): Promise<void> {
-  // In production, this would call Supabase to clean up test data
-  // For now, this is a placeholder
-  // You might want to:
-  // 1. Delete all projects created by test user
-  // 2. Delete all generations
-  // 3. Delete uploaded files from storage
-}
-
-/**
- * Creates a test user account
- */
-export async function createTestUser(page: Page, email: string, password: string): Promise<void> {
-  await page.goto('/signup');
-
-  await page.getByLabel(/email/i).fill(email);
-  await page
-    .getByLabel(/password/i)
-    .first()
-    .fill(password);
-
-  // If there's a confirm password field
-  const confirmPasswordField = page.getByLabel(/confirm.*password/i);
-  if ((await confirmPasswordField.count()) > 0) {
-    await confirmPasswordField.fill(password);
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY for authenticated E2E tests');
   }
 
-  await page.getByRole('button', { name: /sign up|create account/i }).click();
+  const adminSupabase = createClient(supabaseUrl, serviceRoleKey);
+  const uniqueId = crypto.randomUUID();
+  const testEmail = `test-${uniqueId}@example.com`;
+  const testPassword = crypto.randomBytes(16).toString('hex');
 
-  // Wait for redirect
-  await page.waitForURL(/\/dashboard|\/projects/, { timeout: 10000 });
+  const { data: createdUser, error: createError } = await adminSupabase.auth.admin.createUser({
+    email: testEmail,
+    password: testPassword,
+    email_confirm: true,
+  });
+
+  if (createError || !createdUser.user) {
+    throw new Error(`Failed to create test user: ${createError?.message || 'unknown'}`);
+  }
+
+  await page.goto('/signin');
+  await page.getByLabel(/email/i).fill(testEmail);
+  await page.getByLabel(/password/i).fill(testPassword);
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await page.waitForURL((url) => !url.pathname.includes('/signin'), {
+    timeout: 10000,
+  });
+
+  return { email: testEmail, password: testPassword, id: createdUser.user.id };
 }
 
-/**
- * Signs out the current user
- */
+export async function cleanupTestData(userId?: string): Promise<void> {
+  if (!userId) return;
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) return;
+
+  const adminSupabase = createClient(supabaseUrl, serviceRoleKey);
+
+  try {
+    await adminSupabase.from('components').delete().eq('user_id', userId);
+    await adminSupabase.from('generations').delete().eq('user_id', userId);
+    await adminSupabase.from('projects').delete().eq('user_id', userId);
+    await adminSupabase.auth.admin.deleteUser(userId);
+  } catch (e) {
+    console.warn('Failed to cleanup test user:', e);
+  }
+}
+
 export async function signOut(page: Page): Promise<void> {
-  // Click user menu
   const userMenuButton = page
     .locator('button[aria-label*="user"]')
     .or(page.locator('button').filter({ has: page.locator('img[alt*="avatar"]') }));
 
   if ((await userMenuButton.count()) > 0) {
     await userMenuButton.click();
-
-    // Click sign out
     await page.getByRole('menuitem', { name: /sign out/i }).click();
-
-    // Wait for redirect to signin
     await page.waitForURL('/signin', { timeout: 5000 });
   }
 }

--- a/apps/web/e2e/projects.spec.ts
+++ b/apps/web/e2e/projects.spec.ts
@@ -1,16 +1,9 @@
-import { test, expect } from '@playwright/test';
-import { setupAuthenticatedUser, cleanupTestData } from './helpers/auth';
+import { test, expect } from './fixtures';
 
 test.describe('Project Management', () => {
-  test.beforeEach(async ({ page }) => {
-    await setupAuthenticatedUser(page);
-  });
+  test.skip(!process.env.SUPABASE_SERVICE_ROLE_KEY, 'Requires SUPABASE_SERVICE_ROLE_KEY');
 
-  test.afterEach(async () => {
-    await cleanupTestData();
-  });
-
-  test('should display projects page', async ({ page }) => {
+  test('should display projects page', async ({ authenticatedPage: page }) => {
     await page.goto('/projects');
 
     // Check page title and description
@@ -21,7 +14,7 @@ test.describe('Project Management', () => {
     await expect(page.getByRole('link', { name: 'New Project' })).toBeVisible();
   });
 
-  test('should create a new project', async ({ page }) => {
+  test('should create a new project', async ({ authenticatedPage: page }) => {
     await page.goto('/projects/new');
 
     // Fill out project form
@@ -40,7 +33,7 @@ test.describe('Project Management', () => {
     await expect(page.getByText('Test Project')).toBeVisible();
   });
 
-  test('should search for projects', async ({ page }) => {
+  test('should search for projects', async ({ authenticatedPage: page }) => {
     // Create test projects first
     await page.goto('/projects/new');
     await page.getByLabel('Project Name *').fill('Search Test Project');
@@ -64,7 +57,7 @@ test.describe('Project Management', () => {
     await expect(page.getByText(/no projects found/i)).toBeVisible();
   });
 
-  test('should filter projects by framework', async ({ page }) => {
+  test('should filter projects by framework', async ({ authenticatedPage: page }) => {
     await page.goto('/projects');
 
     // Check if filter dropdown exists
@@ -84,7 +77,7 @@ test.describe('Project Management', () => {
     }
   });
 
-  test('should edit a project', async ({ page }) => {
+  test('should edit a project', async ({ authenticatedPage: page }) => {
     // Create a project first
     await page.goto('/projects/new');
     await page.getByLabel('Project Name *').fill('Edit Test Project');
@@ -113,7 +106,7 @@ test.describe('Project Management', () => {
     await expect(page.getByText('Updated Project Name')).toBeVisible();
   });
 
-  test('should delete a project', async ({ page }) => {
+  test('should delete a project', async ({ authenticatedPage: page }) => {
     // Create a project first
     await page.goto('/projects/new');
     await page.getByLabel('Project Name *').fill('Delete Test Project');
@@ -141,7 +134,7 @@ test.describe('Project Management', () => {
     await expect(page.getByText('Delete Test Project')).not.toBeVisible();
   });
 
-  test('should upload project thumbnail', async ({ page }) => {
+  test('should upload project thumbnail', async ({ authenticatedPage: page }) => {
     await page.goto('/projects/new');
 
     await page.getByLabel('Project Name *').fill('Thumbnail Test Project');
@@ -172,7 +165,7 @@ test.describe('Project Management', () => {
     await expect(page).toHaveURL(/\/projects\/[a-f0-9-]+$/);
   });
 
-  test('should show empty state when no projects exist', async ({ page }) => {
+  test('should show empty state when no projects exist', async ({ authenticatedPage: page }) => {
     await page.goto('/projects');
 
     // If no projects, should show empty state
@@ -187,7 +180,7 @@ test.describe('Project Management', () => {
     }
   });
 
-  test('should handle project creation validation errors', async ({ page }) => {
+  test('should handle project creation validation errors', async ({ authenticatedPage: page }) => {
     await page.goto('/projects/new');
 
     // Try to submit without required fields
@@ -199,7 +192,7 @@ test.describe('Project Management', () => {
     ).toBeVisible();
   });
 
-  test('should navigate between grid and list views', async ({ page }) => {
+  test('should navigate between grid and list views', async ({ authenticatedPage: page }) => {
     await page.goto('/projects');
 
     // Look for view toggle buttons


### PR DESCRIPTION
## Summary
- Migrates generation.spec.ts and projects.spec.ts from broken helpers/auth.ts to fixtures.ts pattern
- Rewrites helpers/auth.ts to use Supabase admin API for user creation/cleanup
- Adds test.skip guards for SUPABASE_SERVICE_ROLE_KEY requirement

The old helpers/auth.ts used hardcoded fake credentials that could never authenticate.

## Test plan
- [ ] Run npx playwright test --project=chromium with local Supabase running
- [ ] Verify generation and projects specs skip without SUPABASE_SERVICE_ROLE_KEY
- [ ] Verify settings.spec.ts and billing.spec.ts still work (untouched)

Generated with Claude Code