### PR TITLE
fix(test): Mock local-auth-bypass in auth and admin tests

### DIFF
--- a/apps/web/src/__tests__/lib/api/admin.test.ts
+++ b/apps/web/src/__tests__/lib/api/admin.test.ts
@@ -1,5 +1,10 @@
 import { verifyAdmin } from '@/lib/api/admin';
 
+jest.mock('@/lib/auth/local-auth-bypass', () => ({
+  isLocalAuthBypassEnabled: () => false,
+  getLocalAuthBypassUser: jest.fn(),
+}));
+
 describe('verifyAdmin', () => {
   it('returns null when no authenticated user is present', async () => {
     const supabase = {

--- a/apps/web/src/lib/api/__tests__/auth.test.ts
+++ b/apps/web/src/lib/api/__tests__/auth.test.ts
@@ -6,9 +6,13 @@ import { verifySession, getSession, verifyOwnership } from '../auth';
 import { UnauthorizedError, ForbiddenError } from '../errors';
 import { createClient } from '@/lib/supabase/server';
 
-// Mock Supabase client
 jest.mock('@/lib/supabase/server', () => ({
   createClient: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/local-auth-bypass', () => ({
+  isLocalAuthBypassEnabled: () => false,
+  getLocalAuthBypassUser: jest.fn(),
 }));
 
 const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;


### PR DESCRIPTION
## Summary
- Mock `isLocalAuthBypassEnabled` as `false` in auth.test.ts and admin.test.ts
- Without this, the bypass returns a hardcoded user, skipping all Supabase mock paths

Fixes 9 failing tests → 706/706 now pass.