### PR TITLE
fix(security): Patch express-rate-limit and dompurify vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siza-webapp",
-  "version": "0.27.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siza-webapp",
-      "version": "0.27.0",
+      "version": "0.31.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -502,7 +502,7 @@
     },
     "apps/web": {
       "name": "@siza/web",
-      "version": "0.27.0",
+      "version": "0.30.0",
       "hasInstallScript": true,
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
@@ -15414,11 +15414,14 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -17082,12 +17085,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -19720,9 +19723,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "typescript": "^5.7.0",
     "wrangler": "^4.65.0"
   },
+  "overrides": {
+    "dompurify": "^3.3.2"
+  },
   "engines": {
     "node": ">=22",
     "npm": ">=10"


### PR DESCRIPTION
## Summary

- **express-rate-limit** 8.2.1→8.3.0: High severity — IPv4-mapped IPv6 addresses bypass per-client rate limiting
- **dompurify** override ≥3.3.2: Moderate — XSS vulnerability (transitive via monaco-editor)
- Production audit: **0 vulnerabilities**

## Test plan

- [ ] CI passes (type-check, lint, unit tests, build)
- [ ] `npm audit --omit=dev` shows 0 vulnerabilities
- [ ] Monaco editor still works in generate page

🤖 Generated with [Claude Code](https://claude.com/claude-code)