### PR TITLE
chore: Release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.32.0] - 2026-03-07
 
 ### Fixed
-- **IDP CI workflows** — Add `@forgespace/core` as devDependency so `forge-scorecard` and `forge-policy` bin commands resolve correctly via `npx`
+- **Deploy** — Stub `@vercel/og` JS wrapper + WASM before build, fitting Workers 3 MiB limit (#298)
+- **IDP CI workflows** — Add `@forgespace/core` as devDependency so `forge-scorecard` and `forge-policy` bin commands resolve correctly via `npx` (#300)
 - **Scorecard/Policy workflows** — Remove fallback skip logic (CLI is now published on npm)
+
+### Changed
+- **TemplatePreview** — Remove shiki dynamic import, use plain `<pre>` for code display (reduces bundle) (#299)
+- **Ambient video** — Rename to `ambient-bg.webm` (cleaner path) (#299)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
- Bump version 0.31.0 → 0.32.0
- Ship 3 merged fixes: deploy WASM stub (#298), ambient video + shiki cleanup (#299), IDP CI workflow fix (#300)

## Test plan
- [ ] CI passes
- [ ] release-automation.yml creates tag + GitHub release on merge