### PR TITLE
chore(deps): bump @forgespace/core to ^1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "siza-webapp",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "siza-webapp",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "license": "MIT",
       "workspaces": [
         "apps/*",
@@ -26,7 +26,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.4.1",
         "@commitlint/config-conventional": "^20.4.1",
-        "@forgespace/core": "^1.5.0",
+        "@forgespace/core": "^1.6.0",
         "@types/crypto-js": "^4.2.2",
         "@types/node": "^22.0.0",
         "depcheck": "^1.4.7",
@@ -4153,9 +4153,9 @@
       "license": "MIT"
     },
     "node_modules/@forgespace/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@forgespace/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-3WdsK6E0SUeWcLQp5e1nJy23w+NTTiFeixEULgT4sHG/uM//1iQriddy/NaGlY/4GUUwgcXsu3crZtp2OeI2lg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@forgespace/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-1YC8nQqv74TqvbEfJRimoY/okbVxMlkWSLB8YTXpVNN+DyoL656Pp0bV3sg3ca10N8mCd17lN6IUagOgI+JZ0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4167,6 +4167,7 @@
         "semver": "^7.5.4"
       },
       "bin": {
+        "forge-features": "dist/patterns/idp/feature-toggles/cli.js",
         "forge-patterns": "dist/cli.js",
         "forge-policy": "dist/patterns/idp/policy-engine/cli.js",
         "forge-scorecard": "dist/patterns/idp/scorecards/cli.js"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.4.1",
     "@commitlint/config-conventional": "^20.4.1",
-    "@forgespace/core": "^1.5.0",
+    "@forgespace/core": "^1.6.0",
     "@types/crypto-js": "^4.2.2",
     "@types/node": "^22.0.0",
     "depcheck": "^1.4.7",


### PR DESCRIPTION
## Summary
- Bumps `@forgespace/core` from `^1.5.0` to `^1.6.0`
- Picks up `forge-features` CLI and `scoreGeneratedCode()` post-gen scorer

## Test plan
- [x] `npm install` — resolves correctly
- [ ] CI passes (lint, type-check, tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)