### PR TITLE
ci: Skip E2E tests for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build]
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Skip E2E test job when PR author is dependabot[bot]
- Dependabot PRs lack access to repository secrets (Supabase), causing E2E to always fail
- Unblocks automated dependency update merges

## Test plan
- [ ] Verify existing PRs still run E2E
- [ ] Verify dependabot PRs skip E2E job

🤖 Generated with [Claude Code](https://claude.com/claude-code)