### PR TITLE
feat: Post-generation scorecard with inline A-F grading

### DIFF
--- a/apps/web/src/__tests__/lib/features/flags.test.ts
+++ b/apps/web/src/__tests__/lib/features/flags.test.ts
@@ -20,7 +20,7 @@ describe('Feature Flags', () => {
 
   describe('DEFAULT_FEATURE_FLAGS', () => {
     it('should have all flags defined', () => {
-      expect(Object.keys(DEFAULT_FEATURE_FLAGS)).toHaveLength(32);
+      expect(Object.keys(DEFAULT_FEATURE_FLAGS)).toHaveLength(33);
     });
 
     it('should have auth flags enabled by default', () => {
@@ -42,7 +42,7 @@ describe('Feature Flags', () => {
 
   describe('FEATURE_FLAGS array', () => {
     it('should have all flag entries', () => {
-      expect(FEATURE_FLAGS).toHaveLength(32);
+      expect(FEATURE_FLAGS).toHaveLength(33);
     });
 
     it('should have required fields on each entry', () => {
@@ -93,7 +93,7 @@ describe('Feature Flags', () => {
       delete process.env.NEXT_PUBLIC_ENABLE_STRIPE_BILLING;
       delete process.env.NEXT_PUBLIC_ENABLE_USAGE_LIMITS;
       const flags = getAllFeatureFlags();
-      expect(Object.keys(flags)).toHaveLength(32);
+      expect(Object.keys(flags)).toHaveLength(33);
       expect(flags.ENABLE_GOOGLE_SSO).toBe(true);
       expect(flags.ENABLE_STRIPE_BILLING).toBe(false);
     });

--- a/apps/web/src/app/api/generate/route.ts
+++ b/apps/web/src/app/api/generate/route.ts
@@ -181,7 +181,7 @@ export async function POST(request: NextRequest) {
             controller.enqueue(encoder.encode(createSseEvent(event)));
           }
 
-          const qualityReport = runQualityGates(fullCode);
+          const qualityReport = runQualityGates(fullCode, input.framework);
           controller.enqueue(
             encoder.encode(
               createSseEvent({

--- a/apps/web/src/components/generator/QualityBadge.tsx
+++ b/apps/web/src/components/generator/QualityBadge.tsx
@@ -44,6 +44,22 @@ export function QualityBadge({ report }: QualityBadgeProps) {
         {icon}
         {label}
       </button>
+      {report.postGenScore && (
+        <span
+          className={`inline-flex items-center px-2 py-1 text-xs font-bold rounded-md border ${
+            report.postGenScore.grade === 'A'
+              ? 'text-green-400 border-green-800 bg-green-900/30'
+              : report.postGenScore.grade === 'B'
+                ? 'text-blue-400 border-blue-800 bg-blue-900/30'
+                : report.postGenScore.grade === 'C'
+                  ? 'text-yellow-400 border-yellow-800 bg-yellow-900/30'
+                  : 'text-red-400 border-red-800 bg-red-900/30'
+          }`}
+          title={`Post-gen score: ${report.postGenScore.score}/100`}
+        >
+          {report.postGenScore.grade}
+        </span>
+      )}
       {panelOpen && <QualityPanel report={report} open={panelOpen} onOpenChange={setPanelOpen} />}
     </>
   );

--- a/apps/web/src/lib/features/flags.ts
+++ b/apps/web/src/lib/features/flags.ts
@@ -33,6 +33,7 @@ export const DEFAULT_FEATURE_FLAGS: Record<FeatureFlagName, boolean> = {
   ENABLE_SIZA_GEN_CONTEXT: true,
   ENABLE_SOFTWARE_CATALOG: true,
   ENABLE_GOLDEN_PATHS: true,
+  ENABLE_POST_GEN_SCORING: true,
 };
 
 export const FEATURE_FLAGS: FeatureFlag[] = [
@@ -227,6 +228,12 @@ export const FEATURE_FLAGS: FeatureFlag[] = [
     enabled: DEFAULT_FEATURE_FLAGS.ENABLE_GOLDEN_PATHS,
     description: 'Enable golden path templates for project scaffolding with governance',
     category: 'governance',
+  },
+  {
+    name: 'ENABLE_POST_GEN_SCORING',
+    enabled: DEFAULT_FEATURE_FLAGS.ENABLE_POST_GEN_SCORING,
+    description: 'Run post-generation quality scoring and show A-F grade in preview',
+    category: 'quality',
   },
 ];
 

--- a/apps/web/src/lib/features/types.ts
+++ b/apps/web/src/lib/features/types.ts
@@ -30,7 +30,8 @@ export type FeatureFlagName =
   | 'ENABLE_PROJECT_SCORECARDS'
   | 'ENABLE_SIZA_GEN_CONTEXT'
   | 'ENABLE_SOFTWARE_CATALOG'
-  | 'ENABLE_GOLDEN_PATHS';
+  | 'ENABLE_GOLDEN_PATHS'
+  | 'ENABLE_POST_GEN_SCORING';
 
 export type FeatureFlagCategory =
   | 'auth'

--- a/apps/web/src/lib/quality/gates.ts
+++ b/apps/web/src/lib/quality/gates.ts
@@ -5,11 +5,24 @@ export interface QualityResult {
   severity: 'info' | 'warning' | 'error';
 }
 
+export interface PostGenScoreResult {
+  score: number;
+  grade: 'A' | 'B' | 'C' | 'D' | 'F';
+  passed: boolean;
+  checks: Array<{
+    name: string;
+    passed: boolean;
+    message: string;
+    weight: number;
+  }>;
+}
+
 export interface QualityReport {
   passed: boolean;
   results: QualityResult[];
   score: number;
   timestamp: string;
+  postGenScore?: PostGenScoreResult;
 }
 
 const XSS_PATTERN_STRINGS = [

--- a/apps/web/src/lib/services/generation.service.ts
+++ b/apps/web/src/lib/services/generation.service.ts
@@ -1,7 +1,7 @@
 import { createGeneration, updateGeneration } from '@/lib/repositories/generation.repo';
 import { enrichPromptWithContext } from './context-enrichment';
 import { storeGenerationEmbedding } from './embeddings';
-import { runAllGates, type QualityReport } from '@/lib/quality/gates';
+import { runAllGates, type QualityReport, type PostGenScoreResult } from '@/lib/quality/gates';
 import { incrementGenerationCount } from '@/lib/usage/tracker';
 import { assembleContext } from '@forgespace/siza-gen/lite';
 import { getFeatureFlag } from '@/lib/features/flags';
@@ -139,8 +139,41 @@ export async function failGeneration(generationId: string, errorMessage: string)
   });
 }
 
-export function runQualityGates(code: string): QualityReport {
-  return runAllGates(code);
+export function runQualityGates(code: string, framework?: string): QualityReport {
+  const report = runAllGates(code);
+
+  if (getFeatureFlag('ENABLE_POST_GEN_SCORING')) {
+    try {
+      const {
+        scoreGeneratedCode,
+      } = require('@forgespace/core/dist/patterns/idp/scorecards/post-gen-scorer');
+      const result = scoreGeneratedCode(code, { framework });
+      const gradeMap: Record<string, PostGenScoreResult['grade']> = {
+        A: 'A',
+        B: 'B',
+        C: 'C',
+        D: 'D',
+        F: 'F',
+      };
+      report.postGenScore = {
+        score: result.score,
+        grade: gradeMap[result.grade] ?? 'F',
+        passed: result.passed,
+        checks: result.checks.map(
+          (c: { name: string; passed: boolean; message: string; weight: number }) => ({
+            name: c.name,
+            passed: c.passed,
+            message: c.message,
+            weight: c.weight,
+          })
+        ),
+      };
+    } catch {
+      // Non-blocking — post-gen scoring is optional
+    }
+  }
+
+  return report;
 }
 
 export async function postGenerationTasks(


### PR DESCRIPTION
## Summary

- Integrate `scoreGeneratedCode()` from `@forgespace/core` into the generation pipeline
- After generation completes, post-gen scorer runs 15-25 regex checks (anti-patterns, structure, TypeScript, React-specific)
- A-F grade badge displayed next to quality gates in the generate preview
- Gated behind `ENABLE_POST_GEN_SCORING` feature flag (default: true)
- **Zero new dependencies** — uses existing `@forgespace/core` already in root package.json

### Files Changed (7)
- `apps/web/src/lib/features/types.ts` — Add `ENABLE_POST_GEN_SCORING` flag type
- `apps/web/src/lib/features/flags.ts` — Add flag default + FEATURE_FLAGS entry
- `apps/web/src/lib/quality/gates.ts` — Add `PostGenScoreResult` type to `QualityReport`
- `apps/web/src/lib/services/generation.service.ts` — Call `scoreGeneratedCode()` in `runQualityGates()`
- `apps/web/src/app/api/generate/route.ts` — Pass `framework` to `runQualityGates()`
- `apps/web/src/components/generator/QualityBadge.tsx` — Show A-F grade badge
- `apps/web/src/__tests__/lib/features/flags.test.ts` — Update flag count (32 → 33)

## Test plan

- [x] `tsc --noEmit` passes (zero type errors)
- [x] Flag tests pass (14/14, count updated to 33)
- [x] Quality/generation tests pass (67/67)
- [x] `next build` succeeds
- [ ] CI green
- [ ] Manual: generate a component → verify A-F grade badge appears next to quality gates

Generated with [Claude Code](https://claude.com/claude-code)