### PR TITLE
docs: Add governance guides (scorecard, policy packs, BYOK)

### DIFF
--- a/apps/docs/content/docs/guides/byok-setup.mdx
+++ b/apps/docs/content/docs/guides/byok-setup.mdx
@@ -1,0 +1,103 @@
+---
+title: BYOK Setup
+description: Bring your own API keys for AI providers in Siza.
+icon: Key
+---
+
+## Overview
+
+Siza supports **Bring Your Own Key (BYOK)** — use your personal API keys for AI providers instead of shared quota. This gives you:
+
+- **No generation limits** beyond your provider's rate limits
+- **Direct billing** from the AI provider
+- **Choice of model** across supported providers
+
+## Supported Providers
+
+| Provider | Models | Key Format |
+| --- | --- | --- |
+| Anthropic | Claude Sonnet 4, Claude Haiku | `sk-ant-api03-...` |
+| OpenAI | GPT-4o, GPT-4o-mini | `sk-...` |
+| Google | Gemini 2.5 Flash, Gemini 2.5 Pro | `AIza...` |
+
+## Adding a Key
+
+### Web App
+
+1. Go to **Settings** > **AI Providers**
+2. Click **Add Provider**
+3. Select the provider from the dropdown
+4. Paste your API key
+5. Click **Save**
+
+Your key is encrypted at rest using AES-256-GCM before storage. It is never logged or sent to any service other than the selected provider.
+
+### Environment Variable
+
+For self-hosted deployments, set the key as an environment variable:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-api03-...
+OPENAI_API_KEY=sk-...
+GOOGLE_AI_API_KEY=AIza...
+```
+
+## Key Security
+
+Siza follows a **zero secrets** policy:
+
+- Keys are encrypted before database storage
+- Keys are decrypted only at the moment of API call
+- Keys never appear in logs, error messages, or audit trails
+- Keys are scoped to your user account — no cross-user access
+- The `no-secrets` policy rule scans generated code to prevent accidental key exposure
+
+### Rotation
+
+To rotate a key:
+
+1. Generate a new key from your provider's dashboard
+2. Update the key in **Settings** > **AI Providers**
+3. The old key is immediately overwritten
+
+## Model Selection
+
+Once a BYOK key is configured, you can select specific models during generation:
+
+```text
+Generate a dashboard component using Claude Sonnet 4
+```
+
+The model is passed through the MCP gateway to the appropriate provider. If no model is specified, Siza uses the default for the configured provider.
+
+## Rate Limits
+
+BYOK keys use your provider's rate limits, not Siza's. If you hit a rate limit:
+
+- The error message includes the provider's retry-after header
+- Siza does not retry automatically — you control the pacing
+- Switch to a different provider key to continue generating
+
+## Self-Hosting with BYOK
+
+For self-hosted Siza deployments, BYOK is the primary configuration:
+
+1. Run `npx forge-init` to scaffold governance files
+2. Set provider environment variables in your `.env`
+3. Start Siza — it detects configured providers automatically
+
+No shared API quota is used in self-hosted mode.
+
+## Troubleshooting
+
+| Issue | Fix |
+| --- | --- |
+| "Invalid API key" | Verify the key format matches the provider |
+| "Rate limit exceeded" | Wait for the retry-after period, or switch providers |
+| "Model not available" | Check your provider plan supports the requested model |
+| Key not saving | Ensure the `ENABLE_BYOK_KEYS` feature flag is enabled |
+
+## Next Steps
+
+- [Quality Gates](/docs/guides/quality-gates) — validation applied to all generations regardless of provider
+- [Scorecard Integration](/docs/guides/scorecard-integration) — monitor quality across providers

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -7,6 +7,9 @@
     "templates",
     "mcp-integration",
     "quality-gates",
+    "scorecard-integration",
+    "policy-packs",
+    "byok-setup",
     "github-export",
     "desktop-app",
     "troubleshooting"

--- a/apps/docs/content/docs/guides/policy-packs.mdx
+++ b/apps/docs/content/docs/guides/policy-packs.mdx
@@ -1,0 +1,138 @@
+---
+title: Policy Packs
+description: Define and enforce governance rules across your projects with policy packs.
+icon: ShieldAlert
+---
+
+## Overview
+
+Policy packs are collections of rules that evaluate project artifacts and decide whether to **allow**, **warn**, or **block**. They enforce governance at two checkpoints:
+
+1. **Pre-merge** — CI blocks PRs that violate policies
+2. **Post-generation** — Siza flags violations in generated code
+
+## Built-in Policies
+
+Forge Space ships three default policy packs:
+
+### Security Policy
+
+| Rule | Severity | What it checks |
+| --- | --- | --- |
+| no-secrets | block | No hardcoded credentials or API keys |
+| dep-vulnerabilities | block | No high/critical CVEs in dependencies |
+| safe-html | warn | No unsafe innerHTML injection with user input |
+| secure-links | warn | External links use `rel="noopener noreferrer"` |
+
+### Quality Policy
+
+| Rule | Severity | What it checks |
+| --- | --- | --- |
+| lint-clean | warn | ESLint passes with zero errors |
+| format-consistent | warn | Prettier formatting is consistent |
+| tests-present | warn | New modules have at least one test file |
+| no-large-functions | warn | Functions under 50 lines |
+
+### Compliance Policy
+
+| Rule | Severity | What it checks |
+| --- | --- | --- |
+| license-header | warn | Source files include license header |
+| audit-trail | warn | Generation logs are preserved |
+| feature-flagged | warn | New features behind feature flags |
+
+## Setup
+
+Initialize governance files in your project:
+
+```bash
+npx forge-init
+```
+
+This creates `.forge/policies/` with the three default packs as JSON files.
+
+## Custom Policies
+
+Create a `.forge/policies/custom.policy.json`:
+
+```json
+{
+  "name": "custom",
+  "version": "1.0.0",
+  "rules": [
+    {
+      "id": "max-bundle-size",
+      "description": "Bundle must stay under 3 MiB gzipped",
+      "severity": "block",
+      "check": "bundle-size",
+      "threshold": 3072
+    }
+  ]
+}
+```
+
+### Rule Severities
+
+| Severity | CI Behavior | UI Indicator |
+| --- | --- | --- |
+| `block` | Fails the check, PR cannot merge | Red badge |
+| `warn` | Passes with warning comment | Yellow badge |
+| `info` | Logged only | Grey badge |
+
+## CLI Usage
+
+Evaluate policies from the terminal:
+
+```bash
+npx forge-policy
+```
+
+Options:
+
+| Flag | Description |
+| --- | --- |
+| `--fail-on-block` | Exit 1 if any rule with severity "block" fails |
+| `--policy <path>` | Evaluate a specific policy file |
+| `--dir <path>` | Target directory (default: cwd) |
+| `--json` | Output raw JSON |
+
+## CI Integration
+
+Add a policy check workflow:
+
+```yaml
+name: Policy Check
+on: [pull_request]
+
+jobs:
+  policy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx forge-policy --fail-on-block
+```
+
+If you ran `npx forge-init`, this workflow is already at `.github/workflows/policy-check.yml`.
+
+## Programmatic API
+
+Use the policy engine in your own tools:
+
+```typescript
+import { PolicyLoader, PolicyEvaluator } from "@forgespace/core";
+
+const loader = new PolicyLoader();
+const policies = await loader.loadFromDirectory(".forge/policies");
+const evaluator = new PolicyEvaluator();
+const results = await evaluator.evaluate(policies, projectContext);
+// [{ ruleId: "no-secrets", passed: true }, ...]
+```
+
+## Next Steps
+
+- [Scorecard Integration](/docs/guides/scorecard-integration) — aggregate scores across dimensions
+- [Quality Gates](/docs/guides/quality-gates) — runtime validation during generation

--- a/apps/docs/content/docs/guides/scorecard-integration.mdx
+++ b/apps/docs/content/docs/guides/scorecard-integration.mdx
@@ -1,0 +1,129 @@
+---
+title: Scorecard Integration
+description: Add quality scorecards to your CI pipeline and review generated code quality.
+icon: BarChart3
+---
+
+## Overview
+
+Forge Space scorecards evaluate codebases across four dimensions: **security**, **quality**, **compliance**, and **operations**. Each dimension produces a weighted score, aggregated into an A-F grade.
+
+Scorecards run in two contexts:
+
+1. **Post-generation** — inline in Siza after every AI generation
+2. **CI pipeline** — as a GitHub Actions check on pull requests
+
+## Install
+
+Scorecards are built into `@forgespace/core`. Install it as a dev dependency:
+
+```bash
+npm install -D @forgespace/core
+```
+
+Or initialize a new project with governance files:
+
+```bash
+npx forge-init
+```
+
+This creates `.forge/scorecard.json` with default thresholds.
+
+## Configuration
+
+Edit `.forge/scorecard.json` to set minimum thresholds:
+
+```json
+{
+  "minScore": 70,
+  "weights": {
+    "security": 30,
+    "quality": 30,
+    "compliance": 20,
+    "operations": 20
+  }
+}
+```
+
+### Weights
+
+| Dimension | Default | What it measures |
+| --- | --- | --- |
+| Security | 30% | Zero secrets, dependency vulnerabilities, safe patterns |
+| Quality | 30% | Lint compliance, test coverage, code structure |
+| Compliance | 20% | License headers, audit trail presence |
+| Operations | 20% | Structured logging, health checks, runbook presence |
+
+## CLI Usage
+
+Run a scorecard from the terminal:
+
+```bash
+npx forge-scorecard
+```
+
+Options:
+
+| Flag | Description |
+| --- | --- |
+| `--json` | Output raw JSON instead of summary |
+| `--threshold <n>` | Override minimum score (exit 1 if below) |
+| `--dir <path>` | Target directory (default: cwd) |
+
+Example with threshold:
+
+```bash
+npx forge-scorecard --threshold 80
+```
+
+## CI Integration
+
+Add a GitHub Actions workflow to run scorecards on every PR:
+
+```yaml
+name: Scorecard
+on: [pull_request]
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx forge-scorecard --threshold 70
+```
+
+If you ran `npx forge-init`, this workflow is already at `.github/workflows/scorecard.yml`.
+
+## Post-Generation Scoring
+
+When the `ENABLE_POST_GEN_SCORING` feature flag is enabled in Siza, every AI generation automatically receives an A-F grade. The score appears as a badge next to the generated output.
+
+Grades map to score ranges:
+
+| Grade | Range | Meaning |
+| --- | --- | --- |
+| A | 90-100 | Production-ready |
+| B | 80-89 | Minor improvements suggested |
+| C | 70-79 | Review before shipping |
+| D | 60-69 | Significant issues |
+| F | 0-59 | Regeneration recommended |
+
+## Programmatic API
+
+Use the scorer in your own tools:
+
+```typescript
+import { scoreGeneratedCode } from "@forgespace/core";
+
+const result = scoreGeneratedCode(code, "react");
+// { score: 87, grade: "B", checks: [...] }
+```
+
+## Next Steps
+
+- [Policy Packs](/docs/guides/policy-packs) — enforce rules that block merges
+- [Quality Gates](/docs/guides/quality-gates) — runtime validation during generation


### PR DESCRIPTION
## Summary
- **Scorecard Integration** guide: CI pipeline setup, A-F grading, CLI usage, programmatic API
- **Policy Packs** guide: built-in rules (security/quality/compliance), custom policies, severity levels
- **BYOK Setup** guide: provider key management, encryption, model selection, self-hosting

Part of Phase 2 user acquisition — new users need these guides to adopt governance features.

## Test plan
- [ ] Docs site builds without errors (`cd apps/docs && npm run build`)
- [ ] All 3 new pages render in sidebar under Guides
- [ ] Internal links between guides resolve correctly
- [ ] Meta.json ordering places governance guides after quality-gates

Generated with [Claude Code](https://claude.com/claude-code)