### PR TITLE
feat: Add total generation count to dashboard stats (#333)

### DIFF
--- a/apps/web/src/__tests__/components/dashboard/DashboardClient.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/DashboardClient.test.tsx
@@ -111,6 +111,7 @@ describe('DashboardClient', () => {
       mockUseSubscription.mockReturnValue({
         subscription: null,
         usage: null,
+        generationsTotal: 0,
         isLoading: false,
         error: null,
       } as any);
@@ -129,6 +130,7 @@ describe('DashboardClient', () => {
       mockUseSubscription.mockReturnValue({
         subscription: null,
         usage: null,
+        generationsTotal: 0,
         isLoading: true,
         error: null,
       } as any);
@@ -155,6 +157,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 0,
         },
+        generationsTotal: 0,
         isLoading: false,
         error: null,
       } as any);
@@ -182,6 +185,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 0,
         },
+        generationsTotal: 0,
         isLoading: false,
         error: null,
       } as any);
@@ -206,6 +210,7 @@ describe('DashboardClient', () => {
           projects_limit: -1,
           tokens_used: 5000,
         },
+        generationsTotal: 300,
         isLoading: false,
         error: null,
       } as any);
@@ -230,6 +235,7 @@ describe('DashboardClient', () => {
           projects_limit: -1,
           tokens_used: 50000,
         },
+        generationsTotal: 1500,
         isLoading: false,
         error: null,
       } as any);
@@ -256,6 +262,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 1000,
         },
+        generationsTotal: 30,
         isLoading: false,
         error: null,
       } as any);
@@ -281,6 +288,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 2500,
         },
+        generationsTotal: 75,
         isLoading: false,
         error: null,
       } as any);
@@ -288,8 +296,8 @@ describe('DashboardClient', () => {
       renderWithQueryClient(<DashboardClient />);
 
       expect(screen.getAllByText('Generations').length).toBeGreaterThan(0);
-      expect(screen.getByText('25')).toBeInTheDocument();
-      expect(screen.getByText('of 50 this month')).toBeInTheDocument();
+      expect(screen.getByText('75')).toBeInTheDocument();
+      expect(screen.getByText('25 this month')).toBeInTheDocument();
     });
 
     it('shows unlimited for pro plan generations', () => {
@@ -307,6 +315,7 @@ describe('DashboardClient', () => {
           projects_limit: -1,
           tokens_used: 10000,
         },
+        generationsTotal: 300,
         isLoading: false,
         error: null,
       } as any);
@@ -314,8 +323,8 @@ describe('DashboardClient', () => {
       renderWithQueryClient(<DashboardClient />);
 
       expect(screen.getAllByText('Generations').length).toBeGreaterThan(0);
-      expect(screen.getAllByText('100').length).toBeGreaterThan(0);
-      expect(screen.getByText('Unlimited')).toBeInTheDocument();
+      expect(screen.getByText('300')).toBeInTheDocument();
+      expect(screen.getByText('100 this month')).toBeInTheDocument();
     });
   });
 
@@ -335,6 +344,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 500,
         },
+        generationsTotal: 30,
         isLoading: false,
         error: null,
       } as any);
@@ -359,6 +369,7 @@ describe('DashboardClient', () => {
       mockUseSubscription.mockReturnValue({
         subscription: null,
         usage: null,
+        generationsTotal: 0,
         isLoading: false,
         error: null,
       } as any);
@@ -386,6 +397,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 500,
         },
+        generationsTotal: 30,
         isLoading: false,
         error: null,
       } as any);
@@ -413,6 +425,7 @@ describe('DashboardClient', () => {
           projects_limit: -1,
           tokens_used: 10000,
         },
+        generationsTotal: 300,
         isLoading: false,
         error: null,
       } as any);
@@ -437,6 +450,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 500,
         },
+        generationsTotal: 30,
         isLoading: false,
         error: null,
       } as any);
@@ -462,6 +476,7 @@ describe('DashboardClient', () => {
           projects_limit: -1,
           tokens_used: 10000,
         },
+        generationsTotal: 300,
         isLoading: false,
         error: null,
       } as any);
@@ -488,6 +503,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 0,
         },
+        generationsTotal: 0,
         isLoading: false,
         error: null,
       } as any);
@@ -515,6 +531,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 0,
         },
+        generationsTotal: 0,
         isLoading: false,
         error: null,
       } as any);
@@ -542,6 +559,7 @@ describe('DashboardClient', () => {
           projects_limit: 2,
           tokens_used: 0,
         },
+        generationsTotal: 0,
         isLoading: false,
         error: null,
       } as any);

--- a/apps/web/src/app/(dashboard)/dashboard/dashboard-client.tsx
+++ b/apps/web/src/app/(dashboard)/dashboard/dashboard-client.tsx
@@ -292,7 +292,7 @@ function GovernanceOverview() {
 
 export function DashboardClient() {
   const { data: projects, isLoading: projectsLoading } = useProjects();
-  const { usage, subscription, isLoading: usageLoading } = useSubscription();
+  const { usage, subscription, generationsTotal, isLoading: usageLoading } = useSubscription();
   const goldenPathsEnabled = isFeatureEnabled('ENABLE_GOLDEN_PATHS');
   const { data: goldenPathData } = useGoldenPaths(goldenPathsEnabled ? { limit: 3 } : { limit: 0 });
   const [mountTime] = useState(() => Date.now());
@@ -394,8 +394,8 @@ export function DashboardClient() {
         />
         <StatCard
           label="Generations"
-          value={String(generationsUsed)}
-          subtitle={generationsLimit === -1 ? 'Unlimited' : `of ${generationsLimit} this month`}
+          value={String(generationsTotal)}
+          subtitle={`${generationsUsed} this month`}
           icon={ZapIcon}
           href="/history"
           accent="text-emerald-400"

--- a/apps/web/src/app/api/usage/current/route.ts
+++ b/apps/web/src/app/api/usage/current/route.ts
@@ -17,11 +17,17 @@ export async function GET() {
       .eq('billing_period_start', periodStart)
       .single();
 
-    const { data: sub } = await supabase
-      .from('subscriptions')
-      .select('plan, status, current_period_end, cancel_at_period_end')
-      .eq('user_id', user.id)
-      .single();
+    const [{ data: sub }, { count: generationsTotal }] = await Promise.all([
+      supabase
+        .from('subscriptions')
+        .select('plan, status, current_period_end, cancel_at_period_end')
+        .eq('user_id', user.id)
+        .single(),
+      supabase
+        .from('generations')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id),
+    ]);
 
     return NextResponse.json({
       usage: usage ?? {
@@ -31,6 +37,7 @@ export async function GET() {
         generations_limit: 10,
         projects_limit: 2,
       },
+      generations_total: generationsTotal ?? 0,
       subscription: sub ?? {
         plan: 'free',
         status: 'active',

--- a/apps/web/src/hooks/use-subscription.ts
+++ b/apps/web/src/hooks/use-subscription.ts
@@ -20,6 +20,7 @@ interface Usage {
 interface UsageResponse {
   usage: Usage;
   subscription: Subscription;
+  generations_total: number;
 }
 
 async function fetchUsageData(): Promise<UsageResponse> {
@@ -39,6 +40,7 @@ export function useSubscription() {
   return {
     subscription: data?.subscription ?? null,
     usage: data?.usage ?? null,
+    generationsTotal: data?.generations_total ?? 0,
     isLoading,
     error,
     refetch,


### PR DESCRIPTION
## Summary
- Queries `generations` table for all-time user generation count via `/api/usage/current`
- Dashboard stat card shows **total generations** as main value with **"X this month"** as subtitle
- Mirrors the "Total Projects" card pattern (total + "X this week")

## Changes
- **API** (`/api/usage/current`): Parallel query on `generations` table with `count: 'exact'` + `head: true`
- **Hook** (`useSubscription`): Exposes `generationsTotal` from API response
- **UI** (`dashboard-client.tsx`): Stat card value = total, subtitle = monthly count
- **Tests**: All 18 dashboard tests updated with `generationsTotal` mock data

## Before → After
| | Before | After |
|---|---|---|
| Main value | Monthly count (e.g. "25") | Total all-time (e.g. "75") |
| Subtitle | "of 50 this month" | "25 this month" |

## Test plan
- [x] 18 dashboard tests pass
- [x] 32 total dashboard suite tests pass
- [x] Full monorepo type-check passes
- [x] ESLint + Prettier pass

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)