### PR TITLE
feat: Connect scorecards to catalog entries

### DIFF
--- a/apps/web/src/__tests__/lib/services/catalog.service.test.ts
+++ b/apps/web/src/__tests__/lib/services/catalog.service.test.ts
@@ -154,3 +154,178 @@ describe('listCatalogEntries', () => {
     expect(result.pagination.pages).toBe(3);
   });
 });
+
+describe('getCatalogEntryWithRelations', () => {
+  const mockGetClient = jest.requireMock('@/lib/repositories/base.repo').getClient;
+  const mockGetDeps = catalogRepo.getCatalogDependencies as jest.MockedFunction<
+    typeof catalogRepo.getCatalogDependencies
+  >;
+  const mockGetDependents = catalogRepo.getCatalogDependents as jest.MockedFunction<
+    typeof catalogRepo.getCatalogDependents
+  >;
+  const mockGetChildren = catalogRepo.findCatalogChildren as jest.MockedFunction<
+    typeof catalogRepo.findCatalogChildren
+  >;
+
+  beforeEach(() => {
+    mockGetDeps.mockResolvedValue([]);
+    mockGetDependents.mockResolvedValue([]);
+    mockGetChildren.mockResolvedValue([]);
+  });
+
+  it('returns entry with empty relations when no project_id', async () => {
+    mockFind.mockResolvedValueOnce(mockEntry as any);
+    const result = await catalogService.getCatalogEntryWithRelations('entry-1');
+    expect(result.entry).toEqual(mockEntry);
+    expect(result.dependencies).toEqual([]);
+    expect(result.dependents).toEqual([]);
+    expect(result.children).toEqual([]);
+    expect(result.scorecard).toBeUndefined();
+  });
+
+  it('throws NotFoundError for missing entry', async () => {
+    mockFind.mockResolvedValueOnce(null);
+    await expect(catalogService.getCatalogEntryWithRelations('missing')).rejects.toThrow(
+      NotFoundError
+    );
+  });
+
+  it('transforms scorecard from DB shape to UI shape', async () => {
+    const entryWithProject = { ...mockEntry, project_id: 'proj-1' };
+    mockFind.mockResolvedValueOnce(entryWithProject as any);
+
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: {
+        overall_score: 85,
+        security_score: 90,
+        quality_score: 80,
+        performance_score: 75,
+        compliance_score: 95,
+      },
+      error: null,
+    });
+    const mockLimit = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockOrder = jest.fn().mockReturnValue({ limit: mockLimit });
+    const mockEq = jest.fn().mockReturnValue({ order: mockOrder });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    mockGetClient.mockResolvedValue({
+      from: jest.fn().mockReturnValue({ select: mockSelect }),
+    });
+
+    const result = await catalogService.getCatalogEntryWithRelations('entry-1');
+
+    expect(result.scorecard).toEqual({
+      overall: 85,
+      categories: [
+        { name: 'Security', score: 90 },
+        { name: 'Quality', score: 80 },
+        { name: 'Performance', score: 75 },
+        { name: 'Compliance', score: 95 },
+      ],
+    });
+  });
+
+  it('omits scorecard when project has no scorecard data', async () => {
+    const entryWithProject = { ...mockEntry, project_id: 'proj-1' };
+    mockFind.mockResolvedValueOnce(entryWithProject as any);
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+    const mockLimit = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockOrder = jest.fn().mockReturnValue({ limit: mockLimit });
+    const mockEq = jest.fn().mockReturnValue({ order: mockOrder });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    mockGetClient.mockResolvedValue({
+      from: jest.fn().mockReturnValue({ select: mockSelect }),
+    });
+
+    const result = await catalogService.getCatalogEntryWithRelations('entry-1');
+    expect(result.scorecard).toBeUndefined();
+  });
+});
+
+describe('getScorecardsForEntries', () => {
+  const mockGetClient = jest.requireMock('@/lib/repositories/base.repo').getClient;
+
+  it('returns empty map when no entries have project_id', async () => {
+    const entries = [{ project_id: null }, { project_id: null }];
+    const result = await catalogService.getScorecardsForEntries(entries);
+    expect(result.size).toBe(0);
+  });
+
+  it('batch-fetches scorecards for entries with project_ids', async () => {
+    const entries = [{ project_id: 'proj-1' }, { project_id: 'proj-2' }, { project_id: null }];
+
+    const mockOrder = jest.fn().mockResolvedValue({
+      data: [
+        {
+          project_id: 'proj-1',
+          overall_score: 92,
+          security_score: 95,
+          quality_score: 88,
+          performance_score: 90,
+          compliance_score: 96,
+        },
+        {
+          project_id: 'proj-2',
+          overall_score: 70,
+          security_score: 65,
+          quality_score: 72,
+          performance_score: 68,
+          compliance_score: 75,
+        },
+      ],
+    });
+    const mockIn = jest.fn().mockReturnValue({ order: mockOrder });
+    const mockSelect = jest.fn().mockReturnValue({ in: mockIn });
+    mockGetClient.mockResolvedValue({
+      from: jest.fn().mockReturnValue({ select: mockSelect }),
+    });
+
+    const result = await catalogService.getScorecardsForEntries(entries);
+
+    expect(result.size).toBe(2);
+    expect(result.get('proj-1')).toEqual({
+      overall: 92,
+      categories: [
+        { name: 'Security', score: 95 },
+        { name: 'Quality', score: 88 },
+        { name: 'Performance', score: 90 },
+        { name: 'Compliance', score: 96 },
+      ],
+    });
+    expect(result.get('proj-2')?.overall).toBe(70);
+  });
+
+  it('deduplicates by keeping first scorecard per project', async () => {
+    const entries = [{ project_id: 'proj-1' }];
+
+    const mockOrder = jest.fn().mockResolvedValue({
+      data: [
+        {
+          project_id: 'proj-1',
+          overall_score: 90,
+          security_score: 90,
+          quality_score: 85,
+          performance_score: 80,
+          compliance_score: 95,
+        },
+        {
+          project_id: 'proj-1',
+          overall_score: 60,
+          security_score: 60,
+          quality_score: 55,
+          performance_score: 50,
+          compliance_score: 65,
+        },
+      ],
+    });
+    const mockIn = jest.fn().mockReturnValue({ order: mockOrder });
+    const mockSelect = jest.fn().mockReturnValue({ in: mockIn });
+    mockGetClient.mockResolvedValue({
+      from: jest.fn().mockReturnValue({ select: mockSelect }),
+    });
+
+    const result = await catalogService.getScorecardsForEntries(entries);
+    expect(result.get('proj-1')?.overall).toBe(90);
+  });
+});

--- a/apps/web/src/app/(dashboard)/catalog/catalog-client.tsx
+++ b/apps/web/src/app/(dashboard)/catalog/catalog-client.tsx
@@ -24,6 +24,10 @@ import { Skeleton } from '@siza/ui';
 import { useCatalog, type CatalogFilters } from '@/hooks/use-catalog';
 import type { CatalogEntryRow } from '@/lib/repositories/catalog.repo';
 
+interface CatalogEntryWithScore extends CatalogEntryRow {
+  scorecard?: { overall: number; categories: { name: string; score: number }[] } | null;
+}
+
 const TYPE_META: Record<string, { icon: typeof ServerIcon; label: string }> = {
   service: { icon: ServerIcon, label: 'Service' },
   component: { icon: BoxIcon, label: 'Component' },
@@ -72,7 +76,24 @@ function TypeIcon({ type }: { type: string }) {
   );
 }
 
-function CatalogCard({ entry }: { entry: CatalogEntryRow }) {
+function scoreColor(score: number): string {
+  if (score >= 90) return 'text-emerald-400 bg-emerald-500/10';
+  if (score >= 70) return 'text-sky-400 bg-sky-500/10';
+  if (score >= 50) return 'text-amber-400 bg-amber-500/10';
+  return 'text-red-400 bg-red-500/10';
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-semibold tabular-nums ${scoreColor(score)}`}
+    >
+      {score}
+    </span>
+  );
+}
+
+function CatalogCard({ entry }: { entry: CatalogEntryWithScore }) {
   const meta = TYPE_META[entry.type] || TYPE_META.service;
 
   return (
@@ -118,21 +139,24 @@ function CatalogCard({ entry }: { entry: CatalogEntryRow }) {
           </div>
         )}
 
-        <div className="flex items-center gap-3 text-[11px] text-text-muted">
-          {entry.repository_url && (
-            <span className="flex items-center gap-1">
-              <GitBranchIcon className="w-3 h-3" />
-              Linked
-            </span>
-          )}
-          {entry.dependencies.length > 0 && <span>{entry.dependencies.length} deps</span>}
+        <div className="flex items-center justify-between text-[11px] text-text-muted">
+          <div className="flex items-center gap-3">
+            {entry.repository_url && (
+              <span className="flex items-center gap-1">
+                <GitBranchIcon className="w-3 h-3" />
+                Linked
+              </span>
+            )}
+            {entry.dependencies.length > 0 && <span>{entry.dependencies.length} deps</span>}
+          </div>
+          {entry.scorecard && <ScoreBadge score={entry.scorecard.overall} />}
         </div>
       </div>
     </Link>
   );
 }
 
-function CatalogListItem({ entry }: { entry: CatalogEntryRow }) {
+function CatalogListItem({ entry }: { entry: CatalogEntryWithScore }) {
   const meta = TYPE_META[entry.type] || TYPE_META.service;
 
   return (
@@ -163,6 +187,7 @@ function CatalogListItem({ entry }: { entry: CatalogEntryRow }) {
             {tag}
           </span>
         ))}
+        {entry.scorecard && <ScoreBadge score={entry.scorecard.overall} />}
         {entry.repository_url && <ExternalLinkIcon className="w-3.5 h-3.5 text-text-muted" />}
       </div>
     </Link>

--- a/apps/web/src/app/api/catalog/[id]/route.ts
+++ b/apps/web/src/app/api/catalog/[id]/route.ts
@@ -5,6 +5,7 @@ import {
   noContentResponse,
   errorResponse,
   apiErrorResponse,
+  jsonResponse,
   type APIError,
 } from '@/lib/api';
 import { checkRateLimit, setRateLimitHeaders } from '@/lib/api/rate-limit';
@@ -29,10 +30,23 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return setRateLimitHeaders(response, rateResult, RATE_LIMIT);
     }
 
-    await verifySession();
-    const data = await getCatalogEntryWithRelations(id);
+    const session = await verifySession();
+    const { entry, dependencies, dependents, children, scorecard } =
+      await getCatalogEntryWithRelations(id);
 
-    const response = successResponse(data);
+    const data = {
+      ...entry,
+      dependencies: (dependencies || []).map((d: any) => d.name || d),
+      dependents: (dependents || []).map((d: any) => d.name || d),
+      children,
+      ...(scorecard && { scorecard }),
+    };
+
+    const response = jsonResponse({
+      success: true,
+      data,
+      isOwner: entry.owner_id === session.user.id,
+    });
     return setRateLimitHeaders(response, rateResult, RATE_LIMIT);
   } catch (error) {
     if ((error as APIError).statusCode) {

--- a/apps/web/src/app/api/catalog/route.ts
+++ b/apps/web/src/app/api/catalog/route.ts
@@ -9,7 +9,11 @@ import {
 } from '@/lib/api';
 import { checkRateLimit, setRateLimitHeaders } from '@/lib/api/rate-limit';
 import { insertCatalogEntry } from '@/lib/repositories/catalog.repo';
-import { listCatalogEntries, type CatalogListQuery } from '@/lib/services/catalog.service';
+import {
+  listCatalogEntries,
+  getScorecardsForEntries,
+  type CatalogListQuery,
+} from '@/lib/services/catalog.service';
 import { createCatalogEntrySchema, catalogQuerySchema } from '@/lib/api/validation/catalog';
 
 const RATE_LIMIT = 120;
@@ -31,8 +35,14 @@ export async function GET(request: NextRequest) {
 
     const result = await listCatalogEntries(query as CatalogListQuery);
 
+    const scorecards = await getScorecardsForEntries(result.data);
+    const entries = result.data.map((entry) => ({
+      ...entry,
+      scorecard: entry.project_id ? scorecards.get(entry.project_id) || null : null,
+    }));
+
     const response = successResponse({
-      entries: result.data,
+      entries,
       pagination: result.pagination,
     });
     return setRateLimitHeaders(response, rateResult, RATE_LIMIT);

--- a/apps/web/src/lib/services/catalog.service.ts
+++ b/apps/web/src/lib/services/catalog.service.ts
@@ -12,6 +12,23 @@ import {
 import { ForbiddenError, NotFoundError } from '@/lib/api/errors';
 import { getClient } from '@/lib/repositories/base.repo';
 
+export interface TransformedScorecard {
+  overall: number;
+  categories: { name: string; score: number }[];
+}
+
+function transformScorecard(raw: Record<string, unknown>): TransformedScorecard {
+  return {
+    overall: (raw.overall_score as number) || 0,
+    categories: [
+      { name: 'Security', score: (raw.security_score as number) || 0 },
+      { name: 'Quality', score: (raw.quality_score as number) || 0 },
+      { name: 'Performance', score: (raw.performance_score as number) || 0 },
+      { name: 'Compliance', score: (raw.compliance_score as number) || 0 },
+    ],
+  };
+}
+
 export async function verifyCatalogOwnership(entryId: string, userId: string): Promise<any> {
   const entry = await findCatalogEntryById(entryId);
 
@@ -57,7 +74,7 @@ export async function getCatalogEntryWithRelations(entryId: string): Promise<{
       .single();
 
     if (scorecard) {
-      result.scorecard = scorecard;
+      result.scorecard = transformScorecard(scorecard);
     }
   }
 
@@ -118,4 +135,33 @@ export async function getCatalogStats(): Promise<{
     servicesAndApis: (stats.byType['service'] || 0) + (stats.byType['api'] || 0),
     libsAndComponents: (stats.byType['library'] || 0) + (stats.byType['component'] || 0),
   };
+}
+
+export async function getScorecardsForEntries(
+  entries: Array<{ project_id: string | null }>
+): Promise<Map<string, TransformedScorecard>> {
+  const projectIds = entries.map((e) => e.project_id).filter((id): id is string => id !== null);
+
+  if (projectIds.length === 0) return new Map();
+
+  const supabase = await getClient();
+  const { data } = await supabase
+    .from('project_scorecards')
+    .select(
+      'project_id, overall_score, security_score, quality_score, performance_score, compliance_score'
+    )
+    .in('project_id', projectIds)
+    .order('created_at', { ascending: false });
+
+  const map = new Map<string, TransformedScorecard>();
+  if (!data) return map;
+
+  for (const row of data) {
+    const pid = row.project_id as string;
+    if (!map.has(pid)) {
+      map.set(pid, transformScorecard(row));
+    }
+  }
+
+  return map;
 }


### PR DESCRIPTION
## Summary
- Transform `project_scorecards` DB columns (overall_score, security_score, etc.) into UI-ready `{ overall, categories[] }` shape via service-layer adapter
- Add batch scorecard fetching for catalog list view (single query, deduplicates by most recent)
- Add color-coded `ScoreBadge` component to catalog cards (grid + list views) with thresholds: ≥90 emerald, ≥70 sky, ≥50 amber, <50 red
- Fix catalog detail API to flatten entry with relations and include `isOwner` flag

## Files changed
| File | Change |
|------|--------|
| `catalog.service.ts` | Add `transformScorecard()`, `getScorecardsForEntries()`, `TransformedScorecard` type |
| `catalog/route.ts` | Batch-fetch scorecards for list entries |
| `catalog/[id]/route.ts` | Flatten response + `isOwner` flag |
| `catalog-client.tsx` | `ScoreBadge` component, extended entry type |
| `catalog.service.test.ts` | 7 new tests (16 total) |

## Test plan
- [x] 853 tests passing (74 suites), 0 failures
- [x] Type-check clean across all packages
- [x] Lint + Prettier pass
- [ ] Verify scorecard badges render on catalog list with seeded data
- [ ] Verify detail page shows transformed scorecard categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)