### PR TITLE
chore: Release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.0] - 2026-03-07
+
+### Added
+- **Dashboard generation count** — Shows all-time total generations in stat card with monthly count as subtitle (#333)
+- **Catalog scorecard integration** — Quality badges on catalog entries with linked scorecards (#337)
+- **Governance guides** — Scorecard, policy packs, and BYOK documentation (#335)
+- **catalog-info.yaml** — Backstage-compatible service metadata for IDP self-registration (#338)
+
+### Changed
+- **lucide-react** bumped to 0.577.0 (#334)
+
+---
+
 ## [0.35.0] - 2026-03-07
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siza-webapp",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "private": true,
   "license": "MIT",
   "description": "The open full-stack AI workspace — generate, integrate, ship",


### PR DESCRIPTION
## Summary
Version bump to v0.36.0

## Changes since v0.35.0
- **Dashboard generation count** — All-time total in stat card (#333, #336)
- **Catalog scorecard integration** — Quality badges on catalog entries (#337)
- **Governance guides** — Scorecard, policy packs, BYOK docs (#335)
- **catalog-info.yaml** — Backstage service metadata (#338)
- **lucide-react** bump to 0.577.0 (#334)

🤖 Generated with [Claude Code](https://claude.com/claude-code)