### PR TITLE
feat(docs): Add dark/light theme toggle

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -26,6 +26,33 @@
   --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(245, 158, 11, 0.15);
 }
 
+.light,
+[data-theme='light'] {
+  --color-fd-background: #fafaf9;
+  --color-fd-foreground: #1c1917;
+  --color-fd-muted: #d6d3d1;
+  --color-fd-muted-foreground: #57534e;
+  --color-fd-popover: #ffffff;
+  --color-fd-popover-foreground: #1c1917;
+  --color-fd-card: #ffffff;
+  --color-fd-card-foreground: #1c1917;
+  --color-fd-border: #e7e5e4;
+  --color-fd-primary: #d97706;
+  --color-fd-primary-foreground: #ffffff;
+  --color-fd-secondary: #f5f5f4;
+  --color-fd-secondary-foreground: #1c1917;
+  --color-fd-accent: #ea580c;
+  --color-fd-accent-foreground: #ffffff;
+  --color-fd-ring: #d97706;
+  --border-subtle: rgba(231, 229, 228, 0.8);
+  --border-hover: rgba(217, 119, 6, 0.5);
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.12),
+    0 0 0 1px rgba(217, 119, 6, 0.15);
+  color-scheme: light;
+}
+
+
 @keyframes hero-glow {
   0%,
   100% {
@@ -1114,6 +1141,52 @@
   background: rgba(245, 158, 11, 0.08);
   color: var(--color-fd-muted-foreground);
   border: 1px solid rgba(245, 158, 11, 0.12);
+}
+
+
+/* ── Light mode overrides for hardcoded colors ── */
+
+.light .docs-hero::after,
+[data-theme='light'] .docs-hero::after {
+  background-image: radial-gradient(
+    rgba(28, 25, 23, 0.06) 1px,
+    transparent 1px
+  );
+}
+
+.light .docs-terminal-success,
+[data-theme='light'] .docs-terminal-success {
+  color: #16a34a;
+}
+
+.light .docs-code-string,
+[data-theme='light'] .docs-code-string {
+  color: #16a34a;
+}
+
+.light .docs-code-fn,
+[data-theme='light'] .docs-code-fn {
+  color: #2563eb;
+}
+
+.light .contrib-hero-badge,
+[data-theme='light'] .contrib-hero-badge {
+  color: #7c3aed;
+}
+
+.light .contrib-step-number,
+[data-theme='light'] .contrib-step-number {
+  color: #7c3aed;
+}
+
+.light .flow-node[data-type='start'],
+[data-theme='light'] .flow-node[data-type='start'] {
+  color: #7c3aed;
+}
+
+.light .flow-node[data-type='end'],
+[data-theme='light'] .flow-node[data-type='end'] {
+  color: #059669;
 }
 
 /* ── Interactive Docs Responsive ── */

--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -2,7 +2,7 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 import Image from 'next/image';
 
 export const baseOptions: BaseLayoutProps = {
-  themeSwitch: { enabled: false },
+  themeSwitch: { enabled: true },
   nav: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -34,10 +34,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${jetbrainsMono.variable} ${outfit.variable} dark`}
+      className={`${inter.variable} ${jetbrainsMono.variable} ${outfit.variable}`}
       style={
         {
-          colorScheme: 'dark',
           fontFamily: 'var(--font-inter), system-ui, sans-serif',
           '--font-heading': 'var(--font-outfit)',
         } as React.CSSProperties
@@ -57,9 +56,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body>
-        <RootProvider theme={{ defaultTheme: 'dark', forcedTheme: 'dark' }}>
-          {children}
-        </RootProvider>
+        <RootProvider theme={{ defaultTheme: 'dark' }}>{children}</RootProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Enable Fumadocs built-in theme switcher in docs navbar
- Add light mode CSS variables for all `--color-fd-*` tokens
- Add light mode overrides for hardcoded color values (code syntax, badges, flow diagrams)
- Default theme remains dark; preference persists via localStorage

## Changes
- `layout.tsx`: Remove `forcedTheme: 'dark'`, remove hardcoded `dark` class and `colorScheme`
- `layout.config.tsx`: `themeSwitch: { enabled: true }`
- `globals.css`: Light mode variable block + element-specific overrides

## Test plan
- [ ] Visit docs site → verify dark theme loads by default
- [ ] Click theme toggle in navbar → verify light mode applies cleanly
- [ ] Refresh page → verify theme preference persists
- [ ] Check hero page, code examples, architecture diagram, contributing page in both themes

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)