### PR TITLE
feat: Enhance dependency graph with navigation and lifecycle indicators

### DIFF
--- a/apps/web/src/__tests__/components/catalog/DependencyGraph.test.tsx
+++ b/apps/web/src/__tests__/components/catalog/DependencyGraph.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DependencyGraph } from '@/components/catalog/DependencyGraph';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockGraph = {
+  nodes: [
+    {
+      id: 'n1',
+      name: 'siza-web',
+      display_name: 'Siza Web',
+      type: 'service',
+      lifecycle: 'production',
+      owner_id: 'u1',
+      team: 'Platform',
+      tags: [],
+      dependencies: [],
+      repository_url: null,
+      documentation_url: null,
+      project_id: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    },
+    {
+      id: 'n2',
+      name: 'core',
+      display_name: 'Core Library',
+      type: 'library',
+      lifecycle: 'experimental',
+      owner_id: 'u1',
+      team: 'Platform',
+      tags: [],
+      dependencies: [],
+      repository_url: null,
+      documentation_url: null,
+      project_id: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    },
+  ],
+  edges: [{ source: 'n1', target: 'n2', type: 'dependency' }],
+};
+
+let mockLoading = false;
+let mockData: typeof mockGraph | undefined = undefined;
+
+jest.mock('@/hooks/use-catalog', () => ({
+  useCatalogGraph: () => ({ data: mockData, isLoading: mockLoading }),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLoading = false;
+  mockData = undefined;
+});
+
+describe('DependencyGraph', () => {
+  it('shows loading skeleton', () => {
+    mockLoading = true;
+    const { container } = render(<DependencyGraph />);
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('shows empty state when no nodes', () => {
+    mockData = { nodes: [], edges: [] };
+    render(<DependencyGraph />);
+    expect(screen.getByText('No catalog entries to visualize')).toBeInTheDocument();
+  });
+
+  it('renders nodes with display names', () => {
+    mockData = mockGraph;
+    render(<DependencyGraph />);
+    expect(screen.getByText('Siza Web')).toBeInTheDocument();
+    expect(screen.getByText('Core Library')).toBeInTheDocument();
+  });
+
+  it('renders type labels on nodes', () => {
+    mockData = mockGraph;
+    render(<DependencyGraph />);
+    expect(screen.getByText(/service \u00b7 1 dep/)).toBeInTheDocument();
+    expect(screen.getAllByText('library').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders legend with type colors and edge types', () => {
+    mockData = mockGraph;
+    render(<DependencyGraph />);
+    expect(screen.getByText('dependency')).toBeInTheDocument();
+    expect(screen.getByText('hierarchy')).toBeInTheDocument();
+  });
+
+  it('navigates to entry detail on click', () => {
+    mockData = mockGraph;
+    render(<DependencyGraph />);
+    const node = screen.getByText('Siza Web').closest('g');
+    if (node) fireEvent.click(node);
+    expect(mockPush).toHaveBeenCalledWith('/catalog/n1');
+  });
+
+  it('renders SVG edges between nodes', () => {
+    mockData = mockGraph;
+    const { container } = render(<DependencyGraph />);
+    const paths = container.querySelectorAll('path[stroke-dasharray="4,4"]');
+    expect(paths.length).toBe(1);
+  });
+
+  it('renders lifecycle indicator circles', () => {
+    mockData = mockGraph;
+    const { container } = render(<DependencyGraph />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(2);
+  });
+});

--- a/apps/web/src/app/(dashboard)/catalog/catalog-client.tsx
+++ b/apps/web/src/app/(dashboard)/catalog/catalog-client.tsx
@@ -17,6 +17,7 @@ import {
   LayoutGridIcon,
   ListIcon,
   ArrowUpRightIcon,
+  NetworkIcon,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -316,10 +317,21 @@ export function CatalogClient() {
             )}
           </p>
         </div>
-        <Button className="bg-violet-600 hover:bg-violet-500 shadow-[0_0_20px_rgba(124,58,237,0.15)] hover:shadow-[0_0_28px_rgba(124,58,237,0.25)] transition-all">
-          <PlusIcon className="mr-2 h-4 w-4" />
-          Register
-        </Button>
+        <div className="flex items-center gap-2">
+          <Link href="/catalog/graph">
+            <Button
+              variant="outline"
+              className="border-surface-3 text-text-secondary hover:text-text-primary"
+            >
+              <NetworkIcon className="mr-2 h-4 w-4" />
+              Graph
+            </Button>
+          </Link>
+          <Button className="bg-violet-600 hover:bg-violet-500 shadow-[0_0_20px_rgba(124,58,237,0.15)] hover:shadow-[0_0_28px_rgba(124,58,237,0.25)] transition-all">
+            <PlusIcon className="mr-2 h-4 w-4" />
+            Register
+          </Button>
+        </div>
       </div>
 
       {/* Search and Filters */}

--- a/apps/web/src/app/(dashboard)/catalog/graph/page.tsx
+++ b/apps/web/src/app/(dashboard)/catalog/graph/page.tsx
@@ -1,11 +1,22 @@
 export const dynamic = 'force-dynamic';
 
+import Link from 'next/link';
 import { DependencyGraph } from '@/components/catalog/DependencyGraph';
 
 export default function CatalogGraphPage() {
   return (
     <div className="space-y-6">
       <div>
+        <div className="flex items-center gap-2 mb-1">
+          <Link
+            href="/catalog"
+            className="text-xs text-text-muted hover:text-violet-400 transition-colors"
+          >
+            Catalog
+          </Link>
+          <span className="text-xs text-text-muted">/</span>
+          <span className="text-xs text-text-secondary">Graph</span>
+        </div>
         <h1 className="text-3xl font-bold font-display tracking-tight text-text-primary">
           Catalog Graph
         </h1>

--- a/apps/web/src/app/api/catalog/graph/__tests__/route.test.ts
+++ b/apps/web/src/app/api/catalog/graph/__tests__/route.test.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@/lib/api', () => ({
+  verifySession: jest.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+  errorResponse: jest.fn().mockImplementation((msg, status) => {
+    return new Response(JSON.stringify({ error: msg }), { status });
+  }),
+  apiErrorResponse: jest.fn().mockImplementation((err) => {
+    return new Response(JSON.stringify({ error: err.message }), { status: err.statusCode });
+  }),
+  jsonResponse: jest.fn().mockImplementation((data) => {
+    return new Response(JSON.stringify(data), { status: 200 });
+  }),
+}));
+
+jest.mock('@/lib/api/rate-limit', () => ({
+  checkRateLimit: jest.fn().mockResolvedValue({ allowed: true, remaining: 59, resetAt: 0 }),
+  setRateLimitHeaders: jest.fn().mockImplementation((res) => res),
+}));
+
+jest.mock('@/lib/services/catalog.service', () => ({
+  getCatalogGraph: jest.fn().mockResolvedValue({
+    nodes: [{ id: 'n1', name: 'siza', type: 'service' }],
+    edges: [],
+  }),
+}));
+
+import { GET } from '../route';
+
+const { verifySession } = require('@/lib/api');
+const { checkRateLimit } = require('@/lib/api/rate-limit');
+
+function createRequest() {
+  return new NextRequest('http://localhost/api/catalog/graph');
+}
+
+describe('GET /api/catalog/graph', () => {
+  it('returns graph data for authenticated users', async () => {
+    const res = await GET(createRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.nodes).toHaveLength(1);
+    expect(data.edges).toHaveLength(0);
+  });
+
+  it('requires authentication', async () => {
+    verifySession.mockRejectedValueOnce(
+      Object.assign(new Error('Unauthorized'), { statusCode: 401 })
+    );
+    const res = await GET(createRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('enforces rate limiting', async () => {
+    checkRateLimit.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 30000,
+    });
+    const res = await GET(createRequest());
+    expect(res.status).toBe(429);
+  });
+});

--- a/apps/web/src/app/api/catalog/graph/route.ts
+++ b/apps/web/src/app/api/catalog/graph/route.ts
@@ -1,7 +1,35 @@
-import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import {
+  verifySession,
+  errorResponse,
+  apiErrorResponse,
+  jsonResponse,
+  type APIError,
+} from '@/lib/api';
+import { checkRateLimit, setRateLimitHeaders } from '@/lib/api/rate-limit';
 import { getCatalogGraph } from '@/lib/services/catalog.service';
 
-export async function GET() {
-  const graph = await getCatalogGraph();
-  return NextResponse.json(graph);
+const RATE_LIMIT = 60;
+const RATE_WINDOW = 60000;
+
+export async function GET(request: NextRequest) {
+  try {
+    const rateResult = await checkRateLimit(request, RATE_LIMIT, RATE_WINDOW);
+    if (!rateResult.allowed) {
+      const response = errorResponse('Rate limit exceeded', 429, {
+        retry_after: Math.ceil((rateResult.resetAt - Date.now()) / 1000),
+      });
+      return setRateLimitHeaders(response, rateResult, RATE_LIMIT);
+    }
+
+    await verifySession();
+    const graph = await getCatalogGraph();
+    const response = jsonResponse(graph);
+    return setRateLimitHeaders(response, rateResult, RATE_LIMIT);
+  } catch (error) {
+    if ((error as APIError).statusCode) {
+      return apiErrorResponse(error as APIError);
+    }
+    return errorResponse('An unexpected error occurred', 500);
+  }
 }

--- a/apps/web/src/components/catalog/DependencyGraph.tsx
+++ b/apps/web/src/components/catalog/DependencyGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import type { CatalogEntryRow, CatalogGraphData } from '@/lib/repositories/catalog.repo';
 import { useCatalogGraph } from '@/hooks/use-catalog';
 import { Skeleton } from '@siza/ui';
@@ -15,10 +16,16 @@ const TYPE_COLORS: Record<string, { fill: string; stroke: string }> = {
   website: { fill: '#ec4899', stroke: '#f9a8d4' },
 };
 
-const NODE_W = 160;
-const NODE_H = 48;
-const COL_GAP = 220;
-const ROW_GAP = 72;
+const LIFECYCLE_COLORS: Record<string, string> = {
+  production: '#10b981',
+  experimental: '#f59e0b',
+  deprecated: '#ef4444',
+};
+
+const NODE_W = 180;
+const NODE_H = 56;
+const COL_GAP = 240;
+const ROW_GAP = 76;
 const PAD = 40;
 
 interface LayoutNode {
@@ -64,6 +71,7 @@ function layoutGraph(graph: CatalogGraphData) {
 }
 
 export function DependencyGraph() {
+  const router = useRouter();
   const { data: graph, isLoading } = useCatalogGraph();
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
@@ -82,6 +90,17 @@ export function DependencyGraph() {
     }
     return ids;
   }, [hoveredId, graph]);
+
+  const depCounts = useMemo(() => {
+    if (!graph) return new Map<string, number>();
+    const counts = new Map<string, number>();
+    for (const edge of graph.edges) {
+      if (edge.type === 'dependency') {
+        counts.set(edge.source, (counts.get(edge.source) || 0) + 1);
+      }
+    }
+    return counts;
+  }, [graph]);
 
   if (isLoading) {
     return (
@@ -112,6 +131,19 @@ export function DependencyGraph() {
               <span className="text-[10px] text-text-muted capitalize">{type}</span>
             </div>
           ))}
+          <div className="w-px h-3 bg-surface-3 mx-1" />
+          <div className="flex items-center gap-1.5">
+            <svg width="16" height="2">
+              <line x1="0" y1="1" x2="16" y2="1" stroke="#6b7280" strokeDasharray="3,2" />
+            </svg>
+            <span className="text-[10px] text-text-muted">dependency</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <svg width="16" height="2">
+              <line x1="0" y1="1" x2="16" y2="1" stroke="#7c3aed" />
+            </svg>
+            <span className="text-[10px] text-text-muted">hierarchy</span>
+          </div>
         </div>
       </div>
       <svg
@@ -132,6 +164,17 @@ export function DependencyGraph() {
           >
             <path d="M 0 0 L 10 5 L 0 10 z" fill="#6b7280" />
           </marker>
+          <marker
+            id="arrow-hierarchy"
+            viewBox="0 0 10 10"
+            refX="10"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#7c3aed" />
+          </marker>
         </defs>
         {graph?.edges.map((edge: { source: string; target: string; type: string }, i: number) => {
           const source = nodeMap.get(edge.source);
@@ -150,19 +193,22 @@ export function DependencyGraph() {
               strokeDasharray={edge.type === 'dependency' ? '4,4' : 'none'}
               opacity={highlighted ? 0.8 : 0.15}
               style={{ transition: 'opacity 0.2s' }}
-              markerEnd="url(#arrow)"
+              markerEnd={edge.type === 'hierarchy' ? 'url(#arrow-hierarchy)' : 'url(#arrow)'}
             />
           );
         })}
         {layout.nodes.map((node: LayoutNode) => {
           const colors = TYPE_COLORS[node.entry.type] || TYPE_COLORS.service;
+          const lifecycleColor = LIFECYCLE_COLORS[node.entry.lifecycle] || '#6b7280';
           const opacity = connectedIds.has(node.id) ? 1 : 0.4;
+          const deps = depCounts.get(node.id) || 0;
           return (
             <g
               key={node.id}
               transform={`translate(${node.x}, ${node.y})`}
               onMouseEnter={() => setHoveredId(node.id)}
               onMouseLeave={() => setHoveredId(null)}
+              onClick={() => router.push(`/catalog/${node.id}`)}
               style={{ cursor: 'pointer', opacity, transition: 'opacity 0.2s' }}
             >
               <rect
@@ -172,15 +218,17 @@ export function DependencyGraph() {
                 fill={colors.fill}
                 fillOpacity={0.15}
                 stroke={colors.stroke}
-                strokeWidth={1.5}
+                strokeWidth={hoveredId === node.id ? 2 : 1.5}
               />
-              <text x={12} y={20} fill={colors.stroke} fontSize={12} fontWeight={600}>
-                {node.entry.display_name.length > 18
-                  ? node.entry.display_name.slice(0, 16) + '...'
+              <circle cx={NODE_W - 12} cy={12} r={4} fill={lifecycleColor} />
+              <text x={12} y={22} fill={colors.stroke} fontSize={12} fontWeight={600}>
+                {node.entry.display_name.length > 20
+                  ? node.entry.display_name.slice(0, 18) + '...'
                   : node.entry.display_name}
               </text>
-              <text x={12} y={36} fill="#9ca3af" fontSize={10} fontFamily="monospace">
+              <text x={12} y={42} fill="#9ca3af" fontSize={10} fontFamily="monospace">
                 {node.entry.type}
+                {deps > 0 ? ` \u00b7 ${deps} dep${deps > 1 ? 's' : ''}` : ''}
               </text>
             </g>
           );


### PR DESCRIPTION
## Summary
- Click graph nodes to navigate to catalog entry detail page
- Lifecycle status circles (green=production, amber=experimental, red=deprecated) on each node
- Dependency count displayed on nodes (e.g., "service · 2 deps")
- Enhanced legend showing edge types (dashed=dependency, solid=hierarchy)
- Added authentication + rate limiting to graph API route (was unauthenticated)
- "Graph" button on catalog list page for quick access
- Breadcrumb navigation on graph page

## Test plan
- [x] 8 DependencyGraph component tests (loading, empty, render, navigation, lifecycle, edges)
- [x] 3 graph API route tests (auth, rate limiting, data return)
- [ ] Manual: verify graph page loads and nodes are clickable
- [ ] Manual: verify Graph button appears on catalog list page

🤖 Generated with [Claude Code](https://claude.com/claude-code)