### PR TITLE
feat(docs): Rebrand docs site with Forge Space identity

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -1,54 +1,54 @@
 @import 'fumadocs-ui/style.css';
 
 :root {
-  --color-fd-background: #0c0a09;
-  --color-fd-foreground: #fafaf9;
-  --color-fd-muted: #44403c;
-  --color-fd-muted-foreground: #a8a29e;
-  --color-fd-popover: #1c1917;
-  --color-fd-popover-foreground: #fafaf9;
-  --color-fd-card: #1c1917;
-  --color-fd-card-foreground: #fafaf9;
-  --color-fd-border: #292524;
-  --color-fd-primary: #f59e0b;
-  --color-fd-primary-foreground: #0c0a09;
-  --color-fd-secondary: #1c1917;
-  --color-fd-secondary-foreground: #fafaf9;
-  --color-fd-accent: #fb923c;
-  --color-fd-accent-foreground: #0c0a09;
-  --color-fd-ring: #f59e0b;
+  --color-fd-background: #0c0c0d;
+  --color-fd-foreground: #fafafa;
+  --color-fd-muted: #3f3f46;
+  --color-fd-muted-foreground: #a1a1aa;
+  --color-fd-popover: #18181b;
+  --color-fd-popover-foreground: #fafafa;
+  --color-fd-card: #18181b;
+  --color-fd-card-foreground: #fafafa;
+  --color-fd-border: #27272a;
+  --color-fd-primary: #8B5CF6;
+  --color-fd-primary-foreground: #0c0c0d;
+  --color-fd-secondary: #18181b;
+  --color-fd-secondary-foreground: #fafafa;
+  --color-fd-accent: #A78BFA;
+  --color-fd-accent-foreground: #0c0c0d;
+  --color-fd-ring: #8B5CF6;
   --transition-fast: 150ms ease;
   --transition-default: 200ms ease;
   --ease-siza: cubic-bezier(0.16, 1, 0.3, 1);
-  --border-subtle: rgba(41, 37, 36, 0.8);
-  --border-hover: rgba(245, 158, 11, 0.5);
+  --border-subtle: rgba(63, 63, 70, 0.8);
+  --border-hover: rgba(139, 92, 246, 0.5);
   --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.3);
-  --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(245, 158, 11, 0.15);
+  --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(139, 92, 246, 0.15);
 }
 
 .light,
 [data-theme='light'] {
-  --color-fd-background: #fafaf9;
-  --color-fd-foreground: #1c1917;
-  --color-fd-muted: #d6d3d1;
-  --color-fd-muted-foreground: #57534e;
+  --color-fd-background: #fafafa;
+  --color-fd-foreground: #18181b;
+  --color-fd-muted: #d4d4d8;
+  --color-fd-muted-foreground: #52525b;
   --color-fd-popover: #ffffff;
-  --color-fd-popover-foreground: #1c1917;
+  --color-fd-popover-foreground: #18181b;
   --color-fd-card: #ffffff;
-  --color-fd-card-foreground: #1c1917;
-  --color-fd-border: #e7e5e4;
-  --color-fd-primary: #d97706;
+  --color-fd-card-foreground: #18181b;
+  --color-fd-border: #e4e4e7;
+  --color-fd-primary: #6D28D9;
   --color-fd-primary-foreground: #ffffff;
-  --color-fd-secondary: #f5f5f4;
-  --color-fd-secondary-foreground: #1c1917;
-  --color-fd-accent: #ea580c;
+  --color-fd-secondary: #f4f4f5;
+  --color-fd-secondary-foreground: #18181b;
+  --color-fd-accent: #7C3AED;
   --color-fd-accent-foreground: #ffffff;
-  --color-fd-ring: #d97706;
-  --border-subtle: rgba(231, 229, 228, 0.8);
-  --border-hover: rgba(217, 119, 6, 0.5);
+  --color-fd-ring: #6D28D9;
+  --border-subtle: rgba(228, 228, 231, 0.8);
+  --border-hover: rgba(109, 40, 217, 0.5);
   --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.08);
   --shadow-card-hover: 0 8px 24px rgba(0, 0, 0, 0.12),
-    0 0 0 1px rgba(217, 119, 6, 0.15);
+    0 0 0 1px rgba(109, 40, 217, 0.15);
   color-scheme: light;
 }
 
@@ -97,10 +97,10 @@
 @keyframes pulse-ring {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.4);
+    box-shadow: 0 0 0 0 rgba(139, 92, 246, 0.4);
   }
   50% {
-    box-shadow: 0 0 0 8px rgba(245, 158, 11, 0);
+    box-shadow: 0 0 0 8px rgba(139, 92, 246, 0);
   }
 }
 
@@ -153,11 +153,11 @@
   height: 700px;
   background: conic-gradient(
     from 0deg,
-    rgba(245, 158, 11, 0.12),
-    rgba(251, 146, 60, 0.06),
-    rgba(245, 158, 11, 0.02),
-    rgba(251, 146, 60, 0.06),
-    rgba(245, 158, 11, 0.12)
+    rgba(139, 92, 246, 0.12),
+    rgba(167, 139, 250, 0.06),
+    rgba(139, 92, 246, 0.02),
+    rgba(167, 139, 250, 0.06),
+    rgba(139, 92, 246, 0.12)
   );
   border-radius: 50%;
   animation: conic-spin 12s linear infinite;
@@ -239,12 +239,12 @@
   transition:
     transform var(--transition-default),
     box-shadow var(--transition-default);
-  box-shadow: 0 4px 16px rgba(245, 158, 11, 0.3);
+  box-shadow: 0 4px 16px rgba(139, 92, 246, 0.3);
 }
 
 .docs-cta:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(245, 158, 11, 0.4);
+  box-shadow: 0 8px 24px rgba(139, 92, 246, 0.4);
 }
 
 .docs-cta:active {
@@ -396,7 +396,7 @@
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 0.75rem;
-  background: rgba(245, 158, 11, 0.1);
+  background: rgba(139, 92, 246, 0.1);
   color: var(--color-fd-accent);
   margin-bottom: 1rem;
 }
@@ -501,14 +501,14 @@
 }
 
 .docs-ecosystem-node:hover {
-  border-color: rgba(245, 158, 11, 0.3);
+  border-color: rgba(139, 92, 246, 0.3);
   transform: translateY(-2px);
   box-shadow: var(--shadow-card);
 }
 
 .docs-ecosystem-node--active {
   border-color: var(--color-fd-primary);
-  background: rgba(245, 158, 11, 0.06);
+  background: rgba(139, 92, 246, 0.06);
   animation: pulse-ring 3s ease-in-out infinite;
 }
 
@@ -564,8 +564,8 @@
 
 .docs-tech-pill:hover {
   color: var(--color-fd-foreground);
-  border-color: rgba(245, 158, 11, 0.4);
-  background: rgba(245, 158, 11, 0.08);
+  border-color: rgba(139, 92, 246, 0.4);
+  background: rgba(139, 92, 246, 0.08);
   transform: scale(1.05);
 }
 
@@ -797,9 +797,9 @@
   font-size: 0.65rem;
   padding: 0.15rem 0.45rem;
   border-radius: 4px;
-  background: rgba(245, 158, 11, 0.1);
+  background: rgba(139, 92, 246, 0.1);
   color: var(--color-fd-muted-foreground);
-  border: 1px solid rgba(245, 158, 11, 0.15);
+  border: 1px solid rgba(139, 92, 246, 0.15);
 }
 
 .arch-connector {
@@ -855,8 +855,8 @@
 }
 
 .flow-node[data-type='start'] {
-  background: rgba(245, 158, 11, 0.15);
-  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(139, 92, 246, 0.15);
+  border-color: rgba(139, 92, 246, 0.3);
   color: #a78bfa;
 }
 
@@ -890,11 +890,11 @@
   border-radius: 12px;
   background: linear-gradient(
     135deg,
-    rgba(245, 158, 11, 0.08) 0%,
-    rgba(251, 146, 60, 0.04) 50%,
-    rgba(245, 158, 11, 0.08) 100%
+    rgba(139, 92, 246, 0.08) 0%,
+    rgba(167, 139, 250, 0.04) 50%,
+    rgba(139, 92, 246, 0.08) 100%
   );
-  border: 1px solid rgba(245, 158, 11, 0.15);
+  border: 1px solid rgba(139, 92, 246, 0.15);
 }
 
 .contrib-hero-badge {
@@ -906,8 +906,8 @@
   font-size: 0.75rem;
   font-weight: 600;
   color: #a78bfa;
-  background: rgba(245, 158, 11, 0.12);
-  border: 1px solid rgba(245, 158, 11, 0.2);
+  background: rgba(139, 92, 246, 0.12);
+  border: 1px solid rgba(139, 92, 246, 0.2);
   margin-bottom: 1.25rem;
 }
 
@@ -1014,9 +1014,9 @@
   font-size: 0.65rem;
   padding: 0.2rem 0.5rem;
   border-radius: 4px;
-  background: rgba(245, 158, 11, 0.1);
+  background: rgba(139, 92, 246, 0.1);
   color: var(--color-fd-muted-foreground);
-  border: 1px solid rgba(245, 158, 11, 0.15);
+  border: 1px solid rgba(139, 92, 246, 0.15);
 }
 
 /* Steps */
@@ -1042,7 +1042,7 @@
   width: 32px;
   height: 32px;
   border-radius: 8px;
-  background: rgba(245, 158, 11, 0.12);
+  background: rgba(139, 92, 246, 0.12);
   color: #a78bfa;
   display: flex;
   align-items: center;
@@ -1138,9 +1138,9 @@
   font-size: 0.65rem;
   padding: 0.15rem 0.45rem;
   border-radius: 4px;
-  background: rgba(245, 158, 11, 0.08);
+  background: rgba(139, 92, 246, 0.08);
   color: var(--color-fd-muted-foreground);
-  border: 1px solid rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(139, 92, 246, 0.12);
 }
 
 
@@ -1149,7 +1149,7 @@
 .light .docs-hero::after,
 [data-theme='light'] .docs-hero::after {
   background-image: radial-gradient(
-    rgba(28, 25, 23, 0.06) 1px,
+    rgba(24, 24, 27, 0.06) 1px,
     transparent 1px
   );
 }

--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -2,12 +2,20 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 import Image from 'next/image';
 
 export const baseOptions: BaseLayoutProps = {
-  themeSwitch: { enabled: true },
+  themeSwitch: { enabled: false },
   nav: {
     title: (
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <Image src="/siza-logo.svg" alt="Siza" width={20} height={20} />
-        <span style={{ fontWeight: 700, letterSpacing: '-0.02em' }}>Siza</span>
+        <Image src="/siza-logo.svg" alt="Forge Space" width={20} height={20} />
+        <span
+          style={{
+            fontWeight: 700,
+            letterSpacing: '-0.02em',
+            fontFamily: "var(--font-sora, 'Sora', sans-serif)",
+          }}
+        >
+          Forge Space
+        </span>
       </div>
     ),
   },

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,30 +1,32 @@
 import './globals.css';
-import { Inter, JetBrains_Mono, Outfit } from 'next/font/google';
+import { DM_Sans, IBM_Plex_Mono, Sora } from 'next/font/google';
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 
-const inter = Inter({
-  variable: '--font-inter',
+const dmSans = DM_Sans({
+  variable: '--font-dm-sans',
   subsets: ['latin'],
 });
 
-const outfit = Outfit({
-  variable: '--font-outfit',
+const sora = Sora({
+  variable: '--font-sora',
   subsets: ['latin'],
 });
 
-const jetbrainsMono = JetBrains_Mono({
-  variable: '--font-jetbrains-mono',
+const ibmPlexMono = IBM_Plex_Mono({
+  variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
+  weight: ['400', '500', '600'],
 });
 
 export const metadata: Metadata = {
   title: {
-    template: '%s | Siza Docs',
-    default: 'Siza Documentation',
+    template: '%s | Forge Space Docs',
+    default: 'Forge Space Documentation',
   },
-  description: 'The Open Full-Stack AI Workspace — documentation',
+  description:
+    'The accessible IDP preventing AI limbo engineering. Generate governed code from prompt to production.',
   icons: {
     icon: '/siza-icon.png',
   },
@@ -34,11 +36,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${jetbrainsMono.variable} ${outfit.variable}`}
+      className={`${dmSans.variable} ${ibmPlexMono.variable} ${sora.variable} dark`}
       style={
         {
-          fontFamily: 'var(--font-inter), system-ui, sans-serif',
-          '--font-heading': 'var(--font-outfit)',
+          colorScheme: 'dark',
+          fontFamily: "var(--font-dm-sans), 'DM Sans', system-ui, sans-serif",
+          '--font-heading': 'var(--font-sora)',
         } as React.CSSProperties
       }
       suppressHydrationWarning
@@ -51,12 +54,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
         <style
           dangerouslySetInnerHTML={{
-            __html: ':root{--font-sans:var(--font-inter);--font-mono:var(--font-jetbrains-mono)}',
+            __html: ':root{--font-sans:var(--font-dm-sans);--font-mono:var(--font-ibm-plex-mono)}',
           }}
         />
       </head>
       <body>
-        <RootProvider theme={{ defaultTheme: 'dark' }}>{children}</RootProvider>
+        <RootProvider theme={{ defaultTheme: 'dark', forcedTheme: 'dark' }}>
+          {children}
+        </RootProvider>
       </body>
     </html>
   );

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -1,78 +1,79 @@
 import Link from 'next/link';
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { baseOptions } from './layout.config';
-import { Rocket, Zap, Cloud, Layers } from 'lucide-react';
+import {
+  Shield,
+  Zap,
+  Layers,
+  BarChart3,
+  FileCode,
+  Workflow,
+  Terminal,
+  GitBranch,
+} from 'lucide-react';
 
 const features = [
   {
-    title: 'AI-Powered Generation',
+    title: 'AI Code Generation',
     description:
-      'Generate production-ready React components, pages, and full applications with natural language.',
+      'Generate production-ready components with natural language. Quality-scored at generation time.',
     href: '/docs',
-    Icon: Rocket,
-  },
-  {
-    title: 'MCP Protocol',
-    description:
-      'Connect any AI model via the Model Context Protocol. Works with Claude, Gemini, and more.',
-    href: '/docs/guides/mcp-integration',
     Icon: Zap,
   },
   {
-    title: 'Deploy Anywhere',
+    title: 'Governance Scorecards',
     description:
-      'Self-host on Cloudflare Workers, run locally with the desktop app, or use the hosted platform.',
-    href: '/docs/getting-started/self-hosting',
-    Icon: Cloud,
+      'Automatic A-F quality grading across security, accessibility, lint, and type-safety gates.',
+    href: '/docs/guides/scorecard-integration',
+    Icon: BarChart3,
   },
   {
-    title: 'Full Ecosystem',
+    title: 'Policy Engine',
     description:
-      'Six integrated repos covering generation, routing, branding, and shared standards.',
-    href: '/docs/ecosystem/architecture',
+      'Built-in policy packs for security, quality, and compliance. Block violations before they ship.',
+    href: '/docs/guides/policy-packs',
+    Icon: Shield,
+  },
+  {
+    title: 'Golden Path Templates',
+    description:
+      'Backstage-inspired project scaffolds with CI, testing, linting, and governance baked in.',
+    href: '/docs/guides/golden-path-templates',
+    Icon: FileCode,
+  },
+  {
+    title: 'Service Catalog',
+    description:
+      'Track every service, library, and API across your organization with lifecycle management.',
+    href: '/docs/guides/service-catalog',
     Icon: Layers,
+  },
+  {
+    title: 'MCP-Native Architecture',
+    description:
+      'Gateway-central hub connecting AI providers via Model Context Protocol with full audit trails.',
+    href: '/docs/guides/mcp-integration',
+    Icon: Workflow,
   },
 ];
 
 const techStack = {
-  Frontend: ['React 19', 'Next.js 16', 'shadcn/ui', 'Radix UI'],
-  Backend: ['Supabase', 'Cloudflare Workers', 'Stripe'],
-  AI: ['MCP', 'Claude API', 'Gemini', 'Ollama'],
+  Platform: ['Next.js 16', 'React 19', 'Supabase', 'Cloudflare Workers'],
+  Governance: ['Policy Engine', 'Scorecards', 'Audit Trail', 'Feature Flags'],
+  AI: ['MCP Protocol', 'Claude', 'Gemini', 'Ollama', 'BYOK'],
+  Tooling: ['forge-scorecard', 'forge-policy', 'forge-init', 'forge-features'],
 };
 
 const ecosystem = [
-  {
-    name: 'forge-patterns',
-    desc: 'Shared configs',
-    repo: 'Forge-Space/core',
-    position: 'left-top',
-  },
-  {
-    name: 'siza-gen',
-    desc: 'Generation core',
-    repo: 'Forge-Space/siza-gen',
-    position: 'left-bottom',
-  },
-  {
-    name: 'siza',
-    desc: 'AI workspace',
-    repo: 'Forge-Space/siza',
-    position: 'center',
-    active: true,
-  },
-  { name: 'siza-mcp', desc: 'MCP adapter', repo: 'Forge-Space/ui-mcp', position: 'right-top' },
-  {
-    name: 'mcp-gateway',
-    desc: 'AI routing',
-    repo: 'Forge-Space/mcp-gateway',
-    position: 'right-mid',
-  },
-  {
-    name: 'branding-mcp',
-    desc: 'Brand identity',
-    repo: 'Forge-Space/branding-mcp',
-    position: 'right-bottom',
-  },
+  { name: 'forge-patterns', desc: 'Shared standards & CLI tools', repo: 'Forge-Space/core' },
+  { name: 'mcp-gateway', desc: 'Central auth, routing & audit', repo: 'Forge-Space/mcp-gateway' },
+  { name: 'siza', desc: 'Developer portal & webapp', repo: 'Forge-Space/siza', active: true },
+  { name: 'siza-mcp', desc: 'MCP tool server', repo: 'Forge-Space/ui-mcp' },
+  { name: 'siza-gen', desc: 'Generation engine', repo: 'Forge-Space/siza-gen' },
+  { name: 'branding-mcp', desc: 'Brand identity tools', repo: 'Forge-Space/branding-mcp' },
+  { name: 'brand-guide', desc: 'Design tokens & assets', repo: 'Forge-Space/brand-guide' },
+  { name: 'forgespace-web', desc: 'Marketing site', repo: 'Forge-Space/forgespace-web' },
+  { name: 'siza-desktop', desc: 'Electron desktop app', repo: 'Forge-Space/siza-desktop' },
 ];
 
 export default function HomePage() {
@@ -80,23 +81,22 @@ export default function HomePage() {
     <HomeLayout {...baseOptions}>
       <main className="docs-hero">
         <div className="docs-hero-content">
-          <h1 className="docs-hero-title">Build with Siza</h1>
+          <h1 className="docs-hero-title">Prompt to Prod</h1>
           <p className="docs-hero-subtitle">
-            The open full-stack AI workspace. Generate production-ready UI, connect any model via
-            MCP, and ship to any platform.
+            The accessible Internal Developer Platform that prevents AI limbo engineering. Generate
+            governed code, enforce quality gates, and ship with confidence.
           </p>
           <div className="docs-cta-group">
             <Link href="/docs" className="docs-cta">
               Get Started <span aria-hidden="true">&rarr;</span>
             </Link>
-            <a
-              href="https://github.com/Forge-Space"
+            <Link
+              href="/docs/guides/scorecard-integration"
               className="docs-cta docs-cta--secondary"
-              target="_blank"
-              rel="noopener noreferrer"
             >
-              GitHub
-            </a>
+              <Shield size={16} />
+              Governance Guide
+            </Link>
           </div>
         </div>
 
@@ -109,21 +109,30 @@ export default function HomePage() {
           <div className="docs-terminal-body">
             <div>
               <span className="docs-terminal-prompt">$ </span>
-              <span className="docs-terminal-command">npx siza generate</span>
+              <span className="docs-terminal-command">npx forge-init my-service</span>
             </div>
-            <div className="docs-terminal-output">Generating pricing card component...</div>
-            <div className="docs-terminal-output">Framework: React + Tailwind CSS</div>
+            <div className="docs-terminal-output">Scaffolding from golden path template...</div>
             <div className="docs-terminal-output">
-              Quality score: <span className="docs-terminal-success">94/100</span>
+              Policy pack: forge-defaults (security + quality)
             </div>
-            <div className="docs-terminal-output docs-terminal-success">Done in 3.2s</div>
+            <div>
+              <span className="docs-terminal-prompt">$ </span>
+              <span className="docs-terminal-command">npx forge-scorecard</span>
+            </div>
+            <div className="docs-terminal-output">
+              Overall score: <span className="docs-terminal-success">A (96/100)</span>
+            </div>
+            <div className="docs-terminal-output docs-terminal-success">
+              All governance gates passed
+            </div>
           </div>
         </div>
 
         <section className="docs-section">
-          <h2 className="docs-section-title">Why Siza?</h2>
+          <h2 className="docs-section-title">IDP for the rest of us</h2>
           <p className="docs-section-desc">
-            Everything you need to go from idea to production-ready UI.
+            Like Backstage and Fury, but accessible. Zero-cost-first, gateway-central governance,
+            and MCP-native extensibility.
           </p>
           <div className="docs-card-grid">
             {features.map((f) => (
@@ -139,50 +148,46 @@ export default function HomePage() {
         </section>
 
         <section className="docs-section">
-          <h2 className="docs-section-title">Simple, Powerful API</h2>
+          <h2 className="docs-section-title">Generate with Governance</h2>
           <p className="docs-section-desc">
-            Use MCP tools directly from your IDE or call the REST API.
+            Every generated artifact is scored, validated, and audit-logged automatically.
           </p>
           <div className="docs-code-example">
             <div className="docs-code-header">
-              <span>mcp-tool-call.json</span>
+              <Terminal size={14} />
+              <span>forge-scorecard output</span>
             </div>
             <div className="docs-code-body">
-              <span className="docs-code-line">{'{'}</span>
+              <span className="docs-code-line">
+                <span className="docs-code-fn">Forge Scorecard</span>
+                {' \u2014 my-service'}
+              </span>
+              <span className="docs-code-line">&nbsp;</span>
               <span className="docs-code-line">
                 {'  '}
-                <span className="docs-code-keyword">&quot;tool&quot;</span>
-                {': '}
-                <span className="docs-code-string">&quot;generate_ui_component&quot;</span>
-                {','}
+                <span className="docs-code-string">\u25a0 Security</span>
+                {'     98/100  (zero secrets, deps scanned)'}
               </span>
               <span className="docs-code-line">
                 {'  '}
-                <span className="docs-code-keyword">&quot;input&quot;</span>
-                {': {'}
+                <span className="docs-code-string">\u25a0 Quality</span>
+                {'      95/100  (lint clean, tests passing)'}
               </span>
               <span className="docs-code-line">
-                {'    '}
-                <span className="docs-code-prop">&quot;description&quot;</span>
-                {': '}
-                <span className="docs-code-string">&quot;A pricing card with toggle&quot;</span>
-                {','}
+                {'  '}
+                <span className="docs-code-string">\u25a0 Compliance</span>
+                {'   100/100  (structured logs, runbook)'}
               </span>
               <span className="docs-code-line">
-                {'    '}
-                <span className="docs-code-prop">&quot;framework&quot;</span>
-                {': '}
-                <span className="docs-code-string">&quot;react-tailwind&quot;</span>
-                {','}
+                {'  '}
+                <span className="docs-code-string">\u25a0 Dependencies</span>
+                {' 92/100  (2 outdated, 0 vulns)'}
               </span>
+              <span className="docs-code-line">&nbsp;</span>
               <span className="docs-code-line">
-                {'    '}
-                <span className="docs-code-prop">&quot;mood&quot;</span>
-                {': '}
-                <span className="docs-code-string">&quot;professional&quot;</span>
+                {'  Overall: '}
+                <span className="docs-code-keyword">A (96/100)</span>
               </span>
-              <span className="docs-code-line">{'  }'}</span>
-              <span className="docs-code-line">{'}'}</span>
             </div>
           </div>
         </section>
@@ -190,32 +195,31 @@ export default function HomePage() {
         <section className="docs-section">
           <h2 className="docs-section-title">The Forge Ecosystem</h2>
           <p className="docs-section-desc">
-            Six repositories working together to power AI-driven development.
+            Nine open-source repositories powering governance-first development.
           </p>
-          <div className="docs-ecosystem-hub">
+          <div className="docs-card-grid">
             {ecosystem.map((repo) => (
               <a
                 key={repo.name}
                 href={`https://github.com/${repo.repo}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className={`docs-ecosystem-node ${repo.active ? 'docs-ecosystem-node--active' : ''}`}
-                style={
-                  repo.position === 'center'
-                    ? { gridColumn: '2', gridRow: '2' }
-                    : repo.position === 'left-top'
-                      ? { gridColumn: '1', gridRow: '1' }
-                      : repo.position === 'left-bottom'
-                        ? { gridColumn: '1', gridRow: '3' }
-                        : repo.position === 'right-top'
-                          ? { gridColumn: '3', gridRow: '1' }
-                          : repo.position === 'right-mid'
-                            ? { gridColumn: '3', gridRow: '2' }
-                            : { gridColumn: '3', gridRow: '3' }
-                }
+                className={`docs-card ${repo.active ? 'docs-ecosystem-node--active' : ''}`}
               >
-                <strong>{repo.name}</strong>
-                <span>{repo.desc}</span>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    marginBottom: '0.25rem',
+                  }}
+                >
+                  <GitBranch size={14} />
+                  <span className="docs-card-title" style={{ marginBottom: 0 }}>
+                    {repo.name}
+                  </span>
+                </div>
+                <p className="docs-card-desc">{repo.desc}</p>
               </a>
             ))}
           </div>
@@ -224,7 +228,7 @@ export default function HomePage() {
         <section className="docs-section">
           <h2 className="docs-section-title">Built With</h2>
           <p className="docs-section-desc">
-            Modern stack for fast, reliable, AI-powered development.
+            Modern stack for governed, AI-powered development at any scale.
           </p>
           <div className="docs-tech-categories">
             {Object.entries(techStack).map(([category, items]) => (
@@ -243,13 +247,24 @@ export default function HomePage() {
         </section>
 
         <div className="docs-footer-cta">
-          <h2 className="docs-footer-cta-title">Ready to build?</h2>
+          <h2 className="docs-footer-cta-title">Ready to govern your AI output?</h2>
           <p className="docs-footer-cta-desc">
-            Start generating production-ready components in minutes.
+            Set up governance in minutes. No vendor lock-in, no enterprise gatekeeping.
           </p>
-          <Link href="/docs" className="docs-cta">
-            Get Started <span aria-hidden="true">&rarr;</span>
-          </Link>
+          <div className="docs-cta-group" style={{ justifyContent: 'center' }}>
+            <Link href="/docs" className="docs-cta">
+              Get Started <span aria-hidden="true">&rarr;</span>
+            </Link>
+            <a
+              href="https://github.com/Forge-Space"
+              className="docs-cta docs-cta--secondary"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <GitBranch size={16} />
+              View on GitHub
+            </a>
+          </div>
         </div>
 
         <footer className="docs-footer">
@@ -260,9 +275,12 @@ export default function HomePage() {
             <a href="https://siza.forgespace.co" target="_blank" rel="noopener noreferrer">
               Platform
             </a>
+            <a href="https://forgespace.co" target="_blank" rel="noopener noreferrer">
+              Website
+            </a>
             <Link href="/docs">Docs</Link>
           </div>
-          <span>Siza by Forge Space</span>
+          <span>Forge Space \u2014 Prompt-to-prod with conscience</span>
         </footer>
       </main>
     </HomeLayout>


### PR DESCRIPTION
## Summary

- **Color palette**: Amber/orange → Forge Purple (#8B5CF6/#A78BFA/#6D28D9) across all CSS variables and hardcoded colors
- **Typography**: Inter/Outfit/JetBrains Mono → Sora/DM Sans/IBM Plex Mono (aligned with brand-guide)
- **Neutrals**: Stone → zinc palette for consistent dark theme
- **Homepage**: Complete IDP messaging overhaul — "Prompt to Prod" hero, 6 governance features, 9-repo ecosystem, forge-init/forge-scorecard terminal demo
- **Navigation**: "Siza" → "Forge Space" branding with Sora font
- **Theme**: Forced dark mode with `colorScheme: dark` and `forcedTheme: 'dark'`

## Test plan

- [ ] Verify `NODE_ENV=production next build` passes in `apps/docs/`
- [ ] Check homepage renders correctly with purple palette
- [ ] Verify navigation shows "Forge Space" with Sora font
- [ ] Confirm dark theme is forced (no toggle, no flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)