### PR TITLE
ci: Use org composite action for Node.js setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm run lint
       - run: npm run format:check
 
@@ -28,24 +23,14 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm run type-check
 
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm run test -- --filter=!@siza/desktop -- --coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -59,24 +44,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - run: npm run build -- --filter=!@siza/desktop
 
   security:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
       - name: Run security audit
         run: npm audit --audit-level=moderate
         continue-on-error: true
@@ -119,14 +94,7 @@ jobs:
       - name: Skip E2E for dependabot
         if: github.actor == 'dependabot[bot]'
         run: echo 'Skipping E2E — dependabot PRs lack secrets access'
-      - uses: actions/checkout@v4
-        if: github.actor != 'dependabot[bot]'
-      - uses: actions/setup-node@v4
-        if: github.actor != 'dependabot[bot]'
-        with:
-          node-version: '22'
-          cache: 'npm'
-      - run: npm ci
+      - uses: Forge-Space/.github/.github/actions/setup-node@main
         if: github.actor != 'dependabot[bot]'
       - run: npx playwright install --with-deps chromium
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
## Summary
- Replace repeated checkout + setup-node + npm ci boilerplate with `Forge-Space/.github/.github/actions/setup-node@main` composite action across all 6 CI jobs
- Reduces 38 lines of YAML to 6 (one action call per job)
- Maintains all existing job behavior, conditional logic, and custom steps

## Changes
- **lint**, **type-check**, **test**, **build**, **security** jobs: replaced 3-step setup with single composite action
- **e2e** job: replaced setup steps while preserving `if: github.actor != 'dependabot[bot]'` conditional
- **shell-lint** job: unchanged (no Node.js setup needed)

## Test plan
- [x] Verify CI workflow syntax is valid
- [ ] Confirm all jobs pass on this PR (lint, type-check, test, build, security, shell-lint)
- [ ] Verify E2E job uses composite action correctly with dependabot conditional
- [ ] Check that composite action provides Node.js 22 + npm cache + npm ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)