### PR TITLE
fix: Capitalize "Back to Sign In" on forgot-password page

### DIFF
--- a/apps/web/src/app/(auth)/forgot-password/forgot-password-client.tsx
+++ b/apps/web/src/app/(auth)/forgot-password/forgot-password-client.tsx
@@ -55,7 +55,7 @@ export function ForgotPasswordClient() {
               href="/signin"
               className="mt-6 block w-full rounded-lg bg-primary px-4 py-2 text-center text-sm font-medium text-white hover:bg-primary-hover"
             >
-              Back to sign in
+              Back to Sign In
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Fix missed capitalization from PR #367 — forgot-password page had "Back to sign in" while signup had "Back to Sign In"

## Test Plan
- [x] Lint + type-check pass
- [x] Visual: matches signup page capitalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text capitalization on the forgot password page's back link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->