### PR TITLE
fix: Add Sentry logging to generation providers, fix hardcoded model

### DIFF
--- a/apps/web/src/lib/services/generation.ts
+++ b/apps/web/src/lib/services/generation.ts
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import type { AIProvider } from '@/lib/encryption';
 import type { GenerationEvent, GenerateStreamOptions } from './generation-types';
+import { captureServerError } from '@/lib/sentry/server';
 
 export type { GenerationEvent, GenerateStreamOptions };
 
@@ -92,9 +93,7 @@ export async function* generateWithProvider(
   }
 }
 
-async function* generateWithGoogle(
-  options: GenerateStreamOptions
-): AsyncGenerator<GenerationEvent> {
+async function* generateWithGoogle(options: MultiProviderOptions): AsyncGenerator<GenerationEvent> {
   const apiKey = options.apiKey || process.env.GEMINI_API_KEY;
 
   if (!apiKey) {
@@ -112,7 +111,7 @@ async function* generateWithGoogle(
     const genAI = new GoogleGenerativeAI(apiKey);
     const systemPrompt = getSystemPrompt(options.contextAddition);
     const model = genAI.getGenerativeModel({
-      model: 'gemini-2.5-flash',
+      model: options.model || 'gemini-2.5-flash',
       systemInstruction: systemPrompt,
     });
 
@@ -142,6 +141,10 @@ async function* generateWithGoogle(
 
     yield { type: 'complete', timestamp: Date.now() };
   } catch (error) {
+    captureServerError(error, {
+      route: '/api/generate',
+      extra: { provider: 'google', model: options.model },
+    });
     const detail =
       error instanceof Error ? error.message : 'Please try again or use a different provider.';
     yield {
@@ -222,8 +225,11 @@ async function* generateWithOpenAI(options: MultiProviderOptions): AsyncGenerato
             if (content) {
               yield { type: 'chunk', content, timestamp: Date.now() };
             }
-          } catch {
-            // skip malformed lines
+          } catch (parseError) {
+            captureServerError(parseError, {
+              route: '/api/generate',
+              extra: { provider: 'openai', phase: 'sse-parse' },
+            });
           }
         }
       }
@@ -233,6 +239,10 @@ async function* generateWithOpenAI(options: MultiProviderOptions): AsyncGenerato
 
     yield { type: 'complete', timestamp: Date.now() };
   } catch (error) {
+    captureServerError(error, {
+      route: '/api/generate',
+      extra: { provider: 'openai', model: options.model },
+    });
     const detail = error instanceof Error ? error.message : 'Check your API key and try again.';
     yield {
       type: 'error',
@@ -315,8 +325,11 @@ async function* generateWithAnthropic(
                 yield { type: 'chunk', content: text, timestamp: Date.now() };
               }
             }
-          } catch {
-            // skip malformed lines
+          } catch (parseError) {
+            captureServerError(parseError, {
+              route: '/api/generate',
+              extra: { provider: 'anthropic', phase: 'sse-parse' },
+            });
           }
         }
       }
@@ -326,6 +339,10 @@ async function* generateWithAnthropic(
 
     yield { type: 'complete', timestamp: Date.now() };
   } catch (error) {
+    captureServerError(error, {
+      route: '/api/generate',
+      extra: { provider: 'anthropic', model: options.model },
+    });
     const detail = error instanceof Error ? error.message : 'Check your API key and try again.';
     yield {
       type: 'error',

--- a/apps/web/src/lib/services/provider-router.ts
+++ b/apps/web/src/lib/services/provider-router.ts
@@ -134,7 +134,7 @@ async function* routeViaMcp(opts: RouteGenerationOptions): AsyncGenerator<Genera
   }
 
   if (!hasOutput) {
-    const validProviders: AIProvider[] = ['google', 'openai', 'anthropic', 'siza'];
+    const validProviders: AIProvider[] = ['google', 'openai', 'anthropic'];
     const envProvider = process.env.DEFAULT_GENERATION_PROVIDER;
     const fallbackProvider: AIProvider =
       envProvider && validProviders.includes(envProvider as AIProvider)

--- a/apps/web/src/lib/services/siza-router.ts
+++ b/apps/web/src/lib/services/siza-router.ts
@@ -6,7 +6,7 @@ export interface SizaRoutingResult {
   reason: 'default' | 'vision' | 'quality' | 'free-tier' | 'quota-fallback';
 }
 
-const VALID_PROVIDERS: AIProvider[] = ['google', 'openai', 'anthropic', 'siza'];
+const VALID_PROVIDERS: AIProvider[] = ['google', 'openai', 'anthropic'];
 
 function getDefaultProvider(): { provider: AIProvider; model: string } {
   const envProvider = process.env.DEFAULT_GENERATION_PROVIDER;


### PR DESCRIPTION
## Summary

Follow-up to PR #370 addressing code review critical findings:

- **Fix hardcoded Gemini model** — `generateWithGoogle` now uses `options.model` instead of always using `gemini-2.5-flash`. Users selecting Gemini 1.5 Pro were silently getting the wrong model
- **Add Sentry logging to all provider errors** — Google, OpenAI, and Anthropic error handlers now call `captureServerError` so production failures are visible
- **Add Sentry to SSE parse catch blocks** — Previously empty `catch {}` blocks in OpenAI/Anthropic stream parsers now log parse errors to Sentry
- **Remove `siza` from env var validation** — `DEFAULT_GENERATION_PROVIDER=siza` was accepted but would error in `generateWithProvider`. Now only accepts `google`, `openai`, `anthropic`

## Test plan

- [x] 14 related tests pass (gemini + provider-router suites)
- [x] Type-check clean on changed files
- [ ] Verify Google model selection works (Gemini 1.5 Pro vs 2.5 Flash)
- [ ] Verify Sentry captures generation errors in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostics across AI generation providers with structured error logging and context (provider, model metadata).
  * Added API key validation for Google provider to prevent generation attempts without required credentials.

* **Chores**
  * Removed deprecated generation provider from available routing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->