### PR TITLE
fix: Conversation context, stream timeout, BYOK fallback

### DIFF
--- a/apps/web/src/lib/services/generation.ts
+++ b/apps/web/src/lib/services/generation.ts
@@ -21,6 +21,23 @@ export interface MultiProviderOptions extends GenerateStreamOptions {
 }
 
 function buildPrompt(options: GenerateStreamOptions): string {
+  if (options.conversationContext) {
+    const { previousCode, refinementPrompt, originalPrompt } = options.conversationContext;
+    const parts = [
+      `Refine this ${options.framework} component based on feedback.`,
+      `Original request: ${originalPrompt}`,
+      `Current code:\n\`\`\`\n${previousCode}\n\`\`\``,
+      `Refinement: ${refinementPrompt}`,
+    ];
+    if (options.componentLibrary && options.componentLibrary !== 'none') {
+      parts.push(`Use ${options.componentLibrary} for styling.`);
+    }
+    if (options.typescript) {
+      parts.push('Use TypeScript with proper type annotations.');
+    }
+    return parts.join('\n');
+  }
+
   const parts = [`Generate a ${options.framework} component:`, options.prompt];
   if (options.componentLibrary && options.componentLibrary !== 'none') {
     parts.push(`Use ${options.componentLibrary} for styling.`);
@@ -38,6 +55,22 @@ function buildPrompt(options: GenerateStreamOptions): string {
 
 function getSystemPrompt(contextAddition?: string): string {
   return contextAddition ? `${SYSTEM_PROMPT}\n\n${contextAddition}` : SYSTEM_PROMPT;
+}
+
+const STREAM_TIMEOUT_MS = 30_000;
+
+function readWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  return Promise.race([
+    reader.read(),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('Stream timeout — no data received for 30s')),
+        STREAM_TIMEOUT_MS
+      )
+    ),
+  ]);
 }
 
 export const PROVIDER_MODELS: Record<AIProvider, { id: string; name: string }[]> = {
@@ -213,7 +246,7 @@ async function* generateWithOpenAI(options: MultiProviderOptions): AsyncGenerato
 
     try {
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await readWithTimeout(reader);
         if (done) break;
 
         const chunk = decoder.decode(value);
@@ -311,7 +344,7 @@ async function* generateWithAnthropic(
 
     try {
       while (true) {
-        const { done, value } = await reader.read();
+        const { done, value } = await readWithTimeout(reader);
         if (done) break;
 
         const chunk = decoder.decode(value);

--- a/apps/web/src/lib/services/provider-router.ts
+++ b/apps/web/src/lib/services/provider-router.ts
@@ -235,6 +235,7 @@ async function* routeViaProvider(opts: RouteGenerationOptions): AsyncGenerator<G
     componentLibrary: opts.componentLibrary,
     style: opts.style,
     typescript: opts.typescript,
+    apiKey: opts.userApiKey,
     contextAddition: opts.contextAddition,
     imageBase64: opts.imageBase64,
     imageMimeType: opts.imageMimeType,


### PR DESCRIPTION
## Summary
- **#374**: Multi-turn conversation context — `buildPrompt()` now handles `conversationContext` with previous code + refinement prompt
- **#376**: 30s SSE stream timeout — `readWithTimeout()` helper using `Promise.race`, applied to both OpenAI and Anthropic readers
- **#377**: BYOK API key passed through Anthropic quota fallback path — users' keys no longer silently dropped

## Test plan
- [x] 60 tests pass (generation + provider-router suites)
- [x] Type-check passes across all packages
- [x] ESLint + Prettier clean
- [ ] Manual: verify conversation refinement works end-to-end
- [ ] Manual: verify timeout fires after 30s of silence

Closes #374, #376, #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)