### PR TITLE
feat: Team-based RBAC foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Team-based RBAC** — Teams table, team_members with roles (viewer/editor/admin/owner), entity permissions with hierarchy (view < edit < admin < delete), Supabase RLS policies, repository layer, API routes, TanStack Query hooks, ENABLE_RBAC feature flag, Teams sidebar navigation
+
 ---
 
 ## [0.39.0] - 2026-03-08

--- a/apps/web/src/__tests__/lib/features/flags.test.ts
+++ b/apps/web/src/__tests__/lib/features/flags.test.ts
@@ -20,7 +20,7 @@ describe('Feature Flags', () => {
 
   describe('DEFAULT_FEATURE_FLAGS', () => {
     it('should have all flags defined', () => {
-      expect(Object.keys(DEFAULT_FEATURE_FLAGS)).toHaveLength(34);
+      expect(Object.keys(DEFAULT_FEATURE_FLAGS)).toHaveLength(35);
     });
 
     it('should have auth flags enabled by default', () => {
@@ -42,7 +42,7 @@ describe('Feature Flags', () => {
 
   describe('FEATURE_FLAGS array', () => {
     it('should have all flag entries', () => {
-      expect(FEATURE_FLAGS).toHaveLength(34);
+      expect(FEATURE_FLAGS).toHaveLength(35);
     });
 
     it('should have required fields on each entry', () => {
@@ -93,7 +93,7 @@ describe('Feature Flags', () => {
       delete process.env.NEXT_PUBLIC_ENABLE_STRIPE_BILLING;
       delete process.env.NEXT_PUBLIC_ENABLE_USAGE_LIMITS;
       const flags = getAllFeatureFlags();
-      expect(Object.keys(flags)).toHaveLength(34);
+      expect(Object.keys(flags)).toHaveLength(35);
       expect(flags.ENABLE_GOOGLE_SSO).toBe(true);
       expect(flags.ENABLE_STRIPE_BILLING).toBe(false);
     });

--- a/apps/web/src/app/api/teams/[slug]/route.ts
+++ b/apps/web/src/app/api/teams/[slug]/route.ts
@@ -1,0 +1,149 @@
+import type { NextRequest } from 'next/server';
+import { verifySession } from '@/lib/api/auth';
+import { jsonResponse, errorResponse } from '@/lib/api/response';
+import { UnauthorizedError } from '@/lib/api/errors';
+import {
+  getTeamBySlug,
+  addTeamMember,
+  updateMemberRole,
+  removeTeamMember,
+  getUserRoleInTeam,
+} from '@/lib/repositories/rbac.repo';
+import { captureServerError } from '@/lib/sentry/server';
+
+type RouteContext = { params: Promise<{ slug: string }> };
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const { user } = await verifySession();
+    const { slug } = await context.params;
+
+    const team = await getTeamBySlug(slug);
+    if (!team) {
+      return errorResponse('Team not found', 404);
+    }
+
+    const role = await getUserRoleInTeam(team.id, user.id);
+
+    return jsonResponse({ data: team, userRole: role });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return errorResponse(error.message, error.statusCode);
+    }
+    captureServerError(error, { route: '/api/teams/[slug]' });
+    return errorResponse('Internal server error', 500);
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  try {
+    const { user } = await verifySession();
+    const { slug } = await context.params;
+
+    const team = await getTeamBySlug(slug);
+    if (!team) {
+      return errorResponse('Team not found', 404);
+    }
+
+    const callerRole = await getUserRoleInTeam(team.id, user.id);
+    if (!callerRole || !['admin', 'owner'].includes(callerRole)) {
+      return errorResponse('Insufficient permissions', 403);
+    }
+
+    const body = await request.json();
+    const { userId, role } = body;
+
+    if (!userId || !role) {
+      return errorResponse('userId and role are required', 400);
+    }
+
+    const validRoles = ['viewer', 'editor', 'admin'];
+    if (!validRoles.includes(role)) {
+      return errorResponse('Invalid role', 400);
+    }
+
+    await addTeamMember(team.id, userId, role, user.id);
+    return jsonResponse({ added: true }, 201);
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return errorResponse(error.message, error.statusCode);
+    }
+    if (String(error).includes('duplicate key')) {
+      return errorResponse('User already in team', 409);
+    }
+    captureServerError(error, { route: '/api/teams/[slug]' });
+    return errorResponse('Internal server error', 500);
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const { user } = await verifySession();
+    const { slug } = await context.params;
+
+    const team = await getTeamBySlug(slug);
+    if (!team) {
+      return errorResponse('Team not found', 404);
+    }
+
+    const callerRole = await getUserRoleInTeam(team.id, user.id);
+    if (!callerRole || !['admin', 'owner'].includes(callerRole)) {
+      return errorResponse('Insufficient permissions', 403);
+    }
+
+    const body = await request.json();
+    const { userId, role } = body;
+
+    if (!userId || !role) {
+      return errorResponse('userId and role are required', 400);
+    }
+
+    if (role === 'owner') {
+      return errorResponse('Cannot assign owner role', 400);
+    }
+
+    await updateMemberRole(team.id, userId, role);
+    return jsonResponse({ updated: true });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return errorResponse(error.message, error.statusCode);
+    }
+    captureServerError(error, { route: '/api/teams/[slug]' });
+    return errorResponse('Internal server error', 500);
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  try {
+    const { user } = await verifySession();
+    const { slug } = await context.params;
+
+    const team = await getTeamBySlug(slug);
+    if (!team) {
+      return errorResponse('Team not found', 404);
+    }
+
+    const callerRole = await getUserRoleInTeam(team.id, user.id);
+    if (!callerRole || !['admin', 'owner'].includes(callerRole)) {
+      return errorResponse('Insufficient permissions', 403);
+    }
+
+    const memberId = request.nextUrl.searchParams.get('userId');
+    if (!memberId) {
+      return errorResponse('userId query parameter required', 400);
+    }
+
+    if (memberId === team.owner_id) {
+      return errorResponse('Cannot remove team owner', 400);
+    }
+
+    await removeTeamMember(team.id, memberId);
+    return jsonResponse({ removed: true });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return errorResponse(error.message, error.statusCode);
+    }
+    captureServerError(error, { route: '/api/teams/[slug]' });
+    return errorResponse('Internal server error', 500);
+  }
+}

--- a/apps/web/src/app/api/teams/route.ts
+++ b/apps/web/src/app/api/teams/route.ts
@@ -1,0 +1,49 @@
+import type { NextRequest } from 'next/server';
+import { verifySession } from '@/lib/api/auth';
+import { jsonResponse, errorResponse } from '@/lib/api/response';
+import { UnauthorizedError } from '@/lib/api/errors';
+import { getTeamsForUser, createTeam } from '@/lib/repositories/rbac.repo';
+import { captureServerError } from '@/lib/sentry/server';
+
+export async function GET() {
+  try {
+    const { user } = await verifySession();
+    const teams = await getTeamsForUser(user.id);
+    return jsonResponse({ data: teams });
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return errorResponse(error.message, error.statusCode);
+    }
+    captureServerError(error, { route: '/api/teams' });
+    return errorResponse('Internal server error', 500);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { user } = await verifySession();
+    const body = await request.json();
+
+    const { name, slug, description } = body;
+    if (!name || !slug) {
+      return errorResponse('Name and slug are required', 400);
+    }
+
+    const slugPattern = /^[a-z0-9-]+$/;
+    if (!slugPattern.test(slug)) {
+      return errorResponse('Slug must be lowercase alphanumeric with hyphens', 400);
+    }
+
+    const team = await createTeam(name, slug, user.id, description);
+    return jsonResponse({ data: team }, 201);
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return errorResponse(error.message, error.statusCode);
+    }
+    if (String(error).includes('duplicate key')) {
+      return errorResponse('Team slug already exists', 409);
+    }
+    captureServerError(error, { route: '/api/teams' });
+    return errorResponse('Internal server error', 500);
+  }
+}

--- a/apps/web/src/components/dashboard/navigation.ts
+++ b/apps/web/src/components/dashboard/navigation.ts
@@ -11,6 +11,7 @@ import {
   SettingsIcon,
   ClockIcon,
   ShieldIcon,
+  UsersIcon,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { getFeatureFlag } from '@/lib/features/flags';
@@ -43,6 +44,8 @@ const pluginsNavigation: DashboardNavItem[] = [
   { name: 'Plugins', href: '/plugins', icon: PuzzleIcon },
 ];
 
+const teamsNavigation: DashboardNavItem[] = [{ name: 'Teams', href: '/teams', icon: UsersIcon }];
+
 const adminDashboardNavigation: DashboardNavItem[] = [
   { name: 'Admin', href: '/admin', icon: ShieldIcon },
 ];
@@ -51,9 +54,11 @@ export function getDashboardNavigation(isAdmin: boolean): DashboardNavItem[] {
   const isCatalogEnabled = getFeatureFlag('ENABLE_SOFTWARE_CATALOG');
   const isGoldenPathsEnabled = getFeatureFlag('ENABLE_GOLDEN_PATHS');
   const isPluginsEnabled = getFeatureFlag('ENABLE_PLUGIN_SYSTEM');
+  const isRbacEnabled = getFeatureFlag('ENABLE_RBAC');
   const catalogItems = isCatalogEnabled ? catalogNavigation : [];
   const goldenPathItems = isGoldenPathsEnabled ? goldenPathsNavigation : [];
   const pluginItems = isPluginsEnabled ? pluginsNavigation : [];
+  const teamItems = isRbacEnabled ? teamsNavigation : [];
 
   const projectsIndex = baseDashboardNavigation.findIndex((item) => item.name === 'Projects');
   const navItems = [
@@ -61,6 +66,7 @@ export function getDashboardNavigation(isAdmin: boolean): DashboardNavItem[] {
     ...catalogItems,
     ...goldenPathItems,
     ...pluginItems,
+    ...teamItems,
     ...baseDashboardNavigation.slice(projectsIndex + 1),
   ];
 

--- a/apps/web/src/hooks/use-teams.ts
+++ b/apps/web/src/hooks/use-teams.ts
@@ -1,0 +1,128 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface Team {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  owner_id: string;
+  created_at: string;
+}
+
+interface TeamMember {
+  id: string;
+  team_id: string;
+  user_id: string;
+  role: string;
+  joined_at: string;
+  profile?: { id: string; full_name: string; avatar_url: string | null };
+}
+
+interface TeamWithMembers extends Team {
+  members: TeamMember[];
+}
+
+export function useTeams() {
+  return useQuery<{ data: Team[] }>({
+    queryKey: ['teams'],
+    queryFn: async () => {
+      const res = await fetch('/api/teams');
+      if (!res.ok) throw new Error('Failed to fetch teams');
+      return res.json();
+    },
+  });
+}
+
+export function useTeam(slug: string) {
+  return useQuery<{ data: TeamWithMembers; userRole: string | null }>({
+    queryKey: ['teams', slug],
+    queryFn: async () => {
+      const res = await fetch(`/api/teams/${slug}`);
+      if (!res.ok) throw new Error('Failed to fetch team');
+      return res.json();
+    },
+    enabled: !!slug,
+  });
+}
+
+export function useCreateTeam() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: { name: string; slug: string; description?: string }) => {
+      const res = await fetch('/api/teams', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Failed to create team');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
+    },
+  });
+}
+
+export function useAddTeamMember(slug: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: { userId: string; role: string }) => {
+      const res = await fetch(`/api/teams/${slug}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Failed to add member');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['teams', slug] });
+    },
+  });
+}
+
+export function useUpdateMemberRole(slug: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: { userId: string; role: string }) => {
+      const res = await fetch(`/api/teams/${slug}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Failed to update role');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['teams', slug] });
+    },
+  });
+}
+
+export function useRemoveTeamMember(slug: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (userId: string) => {
+      const res = await fetch(`/api/teams/${slug}?userId=${userId}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Failed to remove member');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['teams', slug] });
+    },
+  });
+}

--- a/apps/web/src/lib/features/flags.ts
+++ b/apps/web/src/lib/features/flags.ts
@@ -35,6 +35,7 @@ export const DEFAULT_FEATURE_FLAGS: Record<FeatureFlagName, boolean> = {
   ENABLE_GOLDEN_PATHS: true,
   ENABLE_POST_GEN_SCORING: true,
   ENABLE_PLUGIN_SYSTEM: true,
+  ENABLE_RBAC: false,
 };
 
 export const FEATURE_FLAGS: FeatureFlag[] = [
@@ -241,6 +242,12 @@ export const FEATURE_FLAGS: FeatureFlag[] = [
     enabled: DEFAULT_FEATURE_FLAGS.ENABLE_PLUGIN_SYSTEM,
     description: 'Enable governance plugin marketplace and widget slot system',
     category: 'governance',
+  },
+  {
+    name: 'ENABLE_RBAC',
+    enabled: DEFAULT_FEATURE_FLAGS.ENABLE_RBAC,
+    description: 'Enable team-based RBAC with roles and entity permissions',
+    category: 'auth',
   },
 ];
 

--- a/apps/web/src/lib/features/types.ts
+++ b/apps/web/src/lib/features/types.ts
@@ -32,7 +32,8 @@ export type FeatureFlagName =
   | 'ENABLE_SOFTWARE_CATALOG'
   | 'ENABLE_GOLDEN_PATHS'
   | 'ENABLE_POST_GEN_SCORING'
-  | 'ENABLE_PLUGIN_SYSTEM';
+  | 'ENABLE_PLUGIN_SYSTEM'
+  | 'ENABLE_RBAC';
 
 export type FeatureFlagCategory =
   | 'auth'

--- a/apps/web/src/lib/repositories/rbac.repo.ts
+++ b/apps/web/src/lib/repositories/rbac.repo.ts
@@ -1,0 +1,170 @@
+import { getClient } from './base.repo';
+
+export type TeamRole = 'viewer' | 'editor' | 'admin' | 'owner';
+export type EntityPermission = 'view' | 'edit' | 'admin' | 'delete';
+export type EntityType = 'catalog_entry' | 'project' | 'template' | 'golden_path';
+
+export interface Team {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  owner_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TeamMember {
+  id: string;
+  team_id: string;
+  user_id: string;
+  role: TeamRole;
+  joined_at: string;
+  profile?: { id: string; full_name: string; avatar_url: string | null };
+}
+
+export interface TeamWithMembers extends Team {
+  members: TeamMember[];
+}
+
+export async function getTeamsForUser(userId: string): Promise<Team[]> {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from('team_members')
+    .select('team:teams(*)')
+    .eq('user_id', userId);
+
+  if (error) throw error;
+  return (data || []).map((d) => d.team as unknown as Team).filter(Boolean);
+}
+
+export async function getTeamBySlug(slug: string): Promise<TeamWithMembers | null> {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from('teams')
+    .select('*, members:team_members(*, profile:profiles(id, full_name, avatar_url))')
+    .eq('slug', slug)
+    .single();
+
+  if (error) return null;
+  return data as TeamWithMembers;
+}
+
+export async function createTeam(
+  name: string,
+  slug: string,
+  ownerId: string,
+  description?: string
+): Promise<Team> {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from('teams')
+    .insert({ name, slug, owner_id: ownerId, description })
+    .select()
+    .single();
+
+  if (error) throw error;
+
+  await supabase.from('team_members').insert({ team_id: data.id, user_id: ownerId, role: 'owner' });
+
+  return data;
+}
+
+export async function addTeamMember(
+  teamId: string,
+  userId: string,
+  role: TeamRole,
+  invitedBy: string
+): Promise<void> {
+  const supabase = await getClient();
+  const { error } = await supabase
+    .from('team_members')
+    .insert({ team_id: teamId, user_id: userId, role, invited_by: invitedBy });
+
+  if (error) throw error;
+}
+
+export async function updateMemberRole(
+  teamId: string,
+  userId: string,
+  role: TeamRole
+): Promise<void> {
+  const supabase = await getClient();
+  const { error } = await supabase
+    .from('team_members')
+    .update({ role })
+    .eq('team_id', teamId)
+    .eq('user_id', userId);
+
+  if (error) throw error;
+}
+
+export async function removeTeamMember(teamId: string, userId: string): Promise<void> {
+  const supabase = await getClient();
+  const { error } = await supabase
+    .from('team_members')
+    .delete()
+    .eq('team_id', teamId)
+    .eq('user_id', userId);
+
+  if (error) throw error;
+}
+
+export async function getUserRoleInTeam(teamId: string, userId: string): Promise<TeamRole | null> {
+  const supabase = await getClient();
+  const { data } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('team_id', teamId)
+    .eq('user_id', userId)
+    .single();
+
+  return data?.role ?? null;
+}
+
+export async function checkEntityPermission(
+  entityType: EntityType,
+  entityId: string,
+  userId: string,
+  requiredPermission: EntityPermission
+): Promise<boolean> {
+  const supabase = await getClient();
+
+  const permissionHierarchy: Record<EntityPermission, EntityPermission[]> = {
+    view: ['view', 'edit', 'admin', 'delete'],
+    edit: ['edit', 'admin', 'delete'],
+    admin: ['admin', 'delete'],
+    delete: ['delete'],
+  };
+
+  const validPermissions = permissionHierarchy[requiredPermission];
+
+  const { data: directPerms } = await supabase
+    .from('entity_permissions')
+    .select('permission')
+    .eq('entity_type', entityType)
+    .eq('entity_id', entityId)
+    .eq('user_id', userId)
+    .in('permission', validPermissions);
+
+  if (directPerms && directPerms.length > 0) return true;
+
+  const { data: teamPerms } = await supabase
+    .from('entity_permissions')
+    .select('permission, team_id')
+    .eq('entity_type', entityType)
+    .eq('entity_id', entityId)
+    .in('permission', validPermissions)
+    .not('team_id', 'is', null);
+
+  if (!teamPerms || teamPerms.length === 0) return false;
+
+  const teamIds = [...new Set(teamPerms.map((p) => p.team_id))];
+  const { data: memberships } = await supabase
+    .from('team_members')
+    .select('team_id')
+    .eq('user_id', userId)
+    .in('team_id', teamIds);
+
+  return (memberships && memberships.length > 0) || false;
+}

--- a/supabase/migrations/20260309000003_team_rbac.sql
+++ b/supabase/migrations/20260309000003_team_rbac.sql
@@ -1,0 +1,91 @@
+-- Team-based RBAC: Teams, membership, and entity permissions
+-- Extends existing profiles.role (user/admin) with team-level granular permissions
+
+-- Teams table
+create table if not exists teams (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text not null unique,
+  description text,
+  owner_id uuid not null references profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index idx_teams_slug on teams(slug);
+create index idx_teams_owner on teams(owner_id);
+
+-- Team membership with roles
+create type team_role as enum ('viewer', 'editor', 'admin', 'owner');
+
+create table if not exists team_members (
+  id uuid primary key default gen_random_uuid(),
+  team_id uuid not null references teams(id) on delete cascade,
+  user_id uuid not null references profiles(id) on delete cascade,
+  role team_role not null default 'viewer',
+  invited_by uuid references profiles(id) on delete set null,
+  joined_at timestamptz not null default now(),
+  constraint team_members_unique unique (team_id, user_id)
+);
+
+create index idx_team_members_team on team_members(team_id);
+create index idx_team_members_user on team_members(user_id);
+
+-- Entity-level permissions (catalog entries, projects)
+create type entity_permission as enum ('view', 'edit', 'admin', 'delete');
+
+create table if not exists entity_permissions (
+  id uuid primary key default gen_random_uuid(),
+  entity_type text not null check (entity_type in ('catalog_entry', 'project', 'template', 'golden_path')),
+  entity_id uuid not null,
+  team_id uuid references teams(id) on delete cascade,
+  user_id uuid references profiles(id) on delete cascade,
+  permission entity_permission not null default 'view',
+  granted_by uuid references profiles(id) on delete set null,
+  granted_at timestamptz not null default now(),
+  constraint entity_permissions_has_grantee check (team_id is not null or user_id is not null),
+  constraint entity_permissions_unique unique (entity_type, entity_id, team_id, user_id, permission)
+);
+
+create index idx_entity_perms_entity on entity_permissions(entity_type, entity_id);
+create index idx_entity_perms_team on entity_permissions(team_id);
+create index idx_entity_perms_user on entity_permissions(user_id);
+
+-- RLS
+alter table teams enable row level security;
+alter table team_members enable row level security;
+alter table entity_permissions enable row level security;
+
+create policy "Authenticated users can view teams"
+  on teams for select
+  using (auth.role() = 'authenticated');
+
+create policy "Team owners can manage teams"
+  on teams for all
+  using (auth.uid() = owner_id);
+
+create policy "Members can view their memberships"
+  on team_members for select
+  using (auth.uid() = user_id or team_id in (
+    select team_id from team_members where user_id = auth.uid() and role in ('admin', 'owner')
+  ));
+
+create policy "Team admins can manage members"
+  on team_members for all
+  using (team_id in (
+    select team_id from team_members where user_id = auth.uid() and role in ('admin', 'owner')
+  ));
+
+create policy "Users can view their entity permissions"
+  on entity_permissions for select
+  using (auth.role() = 'authenticated');
+
+create policy "Entity admins can manage permissions"
+  on entity_permissions for all
+  using (
+    granted_by = auth.uid() or
+    auth.uid() in (
+      select user_id from team_members
+      where team_id = entity_permissions.team_id and role in ('admin', 'owner')
+    )
+  );


### PR DESCRIPTION
## Summary
- **Teams table** with slug, description, owner — supports team creation and discovery
- **Team members** with role hierarchy: `viewer < editor < admin < owner`
- **Entity permissions** with permission hierarchy: `view < edit < admin < delete`
- **Supabase RLS policies** for team visibility, member management (admin/owner only), entity permission grants
- **Repository layer** (`rbac.repo.ts`) with CRUD operations + `checkEntityPermission()` hierarchy check
- **API routes** for `/api/teams` (list/create) and `/api/teams/[slug]` (detail/add/update/remove members)
- **TanStack Query hooks** (`use-teams.ts`) with cache invalidation on mutations
- **`ENABLE_RBAC` feature flag** (disabled by default) gating Teams sidebar navigation
- **Sidebar integration** — Teams nav item appears between Plugins and Templates when flag enabled

## Test plan
- [x] Feature flag tests updated (34 → 35 flags, all 14 tests pass)
- [x] Type-check passes (turbo full cache hit)
- [x] ESLint passes with 0 warnings
- [ ] Manual: Enable `ENABLE_RBAC` flag, verify Teams appears in sidebar
- [ ] Manual: Create team via API, verify RLS policies
- [ ] E2E: Team CRUD flow (future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)