### PR TITLE
test: Add RBAC API route tests

### DIFF
--- a/.serena/memories/rbac_foundation.md
+++ b/.serena/memories/rbac_foundation.md
@@ -1,0 +1,51 @@
+# RBAC Foundation (v0.39.1+)
+
+## Status
+- **Branch**: `feat/teams-ui` (PR #387)
+- **PRs**: 
+  - #386 MERGED (foundation — database schema + repository layer + API routes + hooks)
+  - #387 OPEN (Teams UI — list/create/detail/member management)
+- **Feature Flag**: `ENABLE_RBAC` (35th flag, disabled by default)
+
+## Implementation
+
+### Database Schema (`supabase/migrations/20260309000003_team_rbac.sql`)
+- **teams**: id, name, slug, avatar_url, settings (jsonb), created_at, updated_at
+- **team_members**: id, team_id, user_id, role (owner|admin|member|viewer), joined_at
+- **entity_permissions**: id, team_id, entity_type (project|template|generation), entity_id, permission_level (owner|write|read|none), created_at, updated_at
+- **RLS Policies**: Authenticated users read teams they're members of, owners write, admins manage members
+
+### Repository Layer (`apps/web/src/lib/repositories/rbac.repo.ts`)
+- `createTeam()`, `getTeam()`, `updateTeam()`, `deleteTeam()`
+- `addTeamMember()`, `removeTeamMember()`, `updateMemberRole()`
+- `getTeamMembers()`, `getUserTeams()`
+- `setEntityPermission()`, `getEntityPermission()`, `checkEntityPermission()`
+- **Permission Hierarchy**: owner > write > read > none (owner = full CRUD, write = modify, read = view, none = hidden)
+
+### API Routes
+- `apps/web/src/app/api/teams/route.ts` — GET (list user teams), POST (create team)
+- `apps/web/src/app/api/teams/[slug]/route.ts` — GET team, POST add member, PATCH update member, DELETE remove member
+
+### Frontend Integration
+- `apps/web/src/hooks/use-teams.ts` — TanStack Query hooks (useTeams, useTeam, useCreateTeam, useTeamMembers, useAddMember, useUpdateMember, useRemoveMember)
+- Sidebar navigation: Teams entry gated by `ENABLE_RBAC` flag
+
+## Teams UI Files (PR #387)
+- `apps/web/src/app/(dashboard)/teams/page.tsx` — Teams list page (server component)
+- `apps/web/src/app/(dashboard)/teams/teams-client.tsx` — Team list + create form (client component)
+- `apps/web/src/app/(dashboard)/teams/[id]/page.tsx` — Team detail page (server component)
+- `apps/web/src/app/(dashboard)/teams/[id]/team-detail-client.tsx` — Member management with inline role editing (client component)
+
+**Pattern**: Permission hierarchy uses ordered array `indexOf()` for both `checkEntityPermission()` in repository layer AND member role sorting in UI.
+
+## Next Steps (not yet implemented)
+1. Permission checks in project/template/generation flows
+2. Team switcher in app header
+3. Workspace-level permission inheritance
+4. Audit log integration for permission changes
+
+## Gotchas
+- Feature flag count is now **35** (updated from 34 in flags.test.ts)
+- RBAC is disabled by default — must enable flag in Supabase dashboard or env
+- Permission hierarchy enforced at repository layer, NOT database constraints
+- RLS policies use `user_id = auth.uid()` for security

--- a/apps/web/src/app/api/teams/[slug]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/teams/[slug]/__tests__/route.test.ts
@@ -1,0 +1,196 @@
+import { NextRequest } from 'next/server';
+import { GET, POST, PATCH, DELETE } from '../route';
+import { verifySession } from '@/lib/api/auth';
+import {
+  getTeamBySlug,
+  addTeamMember,
+  updateMemberRole,
+  removeTeamMember,
+  getUserRoleInTeam,
+} from '@/lib/repositories/rbac.repo';
+import { UnauthorizedError } from '@/lib/api/errors';
+
+jest.mock('@/lib/api/auth');
+jest.mock('@/lib/repositories/rbac.repo');
+jest.mock('@/lib/sentry/server', () => ({
+  captureServerError: jest.fn(),
+}));
+
+const mockVerifySession = verifySession as jest.MockedFunction<typeof verifySession>;
+const mockGetTeamBySlug = getTeamBySlug as jest.MockedFunction<typeof getTeamBySlug>;
+const mockAddTeamMember = addTeamMember as jest.MockedFunction<typeof addTeamMember>;
+const mockUpdateMemberRole = updateMemberRole as jest.MockedFunction<typeof updateMemberRole>;
+const mockRemoveTeamMember = removeTeamMember as jest.MockedFunction<typeof removeTeamMember>;
+const mockGetUserRoleInTeam = getUserRoleInTeam as jest.MockedFunction<typeof getUserRoleInTeam>;
+
+const mockUser = { id: 'user-123', email: 'admin@example.com' } as any;
+const mockTeam = {
+  id: 't1',
+  name: 'Platform',
+  slug: 'platform',
+  owner_id: 'user-123',
+  description: null,
+  created_at: '',
+  updated_at: '',
+  members: [{ id: 'm1', team_id: 't1', user_id: 'user-123', role: 'owner', joined_at: '' }],
+};
+
+const context = { params: Promise.resolve({ slug: 'platform' }) };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifySession.mockResolvedValue({ user: mockUser });
+  mockGetTeamBySlug.mockResolvedValue(mockTeam as any);
+  mockGetUserRoleInTeam.mockResolvedValue('owner');
+});
+
+describe('GET /api/teams/[slug]', () => {
+  it('returns team with user role', async () => {
+    const req = new NextRequest('http://localhost/api/teams/platform');
+    const res = await GET(req, context);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.name).toBe('Platform');
+    expect(body.userRole).toBe('owner');
+  });
+
+  it('returns 404 for unknown team', async () => {
+    mockGetTeamBySlug.mockResolvedValue(null);
+
+    const req = new NextRequest('http://localhost/api/teams/unknown');
+    const res = await GET(req, { params: Promise.resolve({ slug: 'unknown' }) });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockVerifySession.mockRejectedValue(new UnauthorizedError());
+
+    const req = new NextRequest('http://localhost/api/teams/platform');
+    const res = await GET(req, context);
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/teams/[slug] — add member', () => {
+  it('adds member as admin', async () => {
+    mockAddTeamMember.mockResolvedValue(undefined);
+
+    const req = new NextRequest('http://localhost/api/teams/platform', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'new-user', role: 'editor' }),
+    });
+
+    const res = await POST(req, context);
+    expect(res.status).toBe(201);
+    expect(mockAddTeamMember).toHaveBeenCalledWith('t1', 'new-user', 'editor', 'user-123');
+  });
+
+  it('returns 403 for viewer trying to add member', async () => {
+    mockGetUserRoleInTeam.mockResolvedValue('viewer');
+
+    const req = new NextRequest('http://localhost/api/teams/platform', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'new-user', role: 'editor' }),
+    });
+
+    const res = await POST(req, context);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid role', async () => {
+    const req = new NextRequest('http://localhost/api/teams/platform', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'new-user', role: 'superadmin' }),
+    });
+
+    const res = await POST(req, context);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 for duplicate member', async () => {
+    mockAddTeamMember.mockRejectedValue(new Error('duplicate key'));
+
+    const req = new NextRequest('http://localhost/api/teams/platform', {
+      method: 'POST',
+      body: JSON.stringify({ userId: 'existing-user', role: 'viewer' }),
+    });
+
+    const res = await POST(req, context);
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('PATCH /api/teams/[slug] — update role', () => {
+  it('updates member role', async () => {
+    mockUpdateMemberRole.mockResolvedValue(undefined);
+
+    const req = new NextRequest('http://localhost/api/teams/platform', {
+      method: 'PATCH',
+      body: JSON.stringify({ userId: 'member-1', role: 'admin' }),
+    });
+
+    const res = await PATCH(req, context);
+    expect(res.status).toBe(200);
+    expect(mockUpdateMemberRole).toHaveBeenCalledWith('t1', 'member-1', 'admin');
+  });
+
+  it('rejects assigning owner role', async () => {
+    const req = new NextRequest('http://localhost/api/teams/platform', {
+      method: 'PATCH',
+      body: JSON.stringify({ userId: 'member-1', role: 'owner' }),
+    });
+
+    const res = await PATCH(req, context);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 for editor trying to change roles', async () => {
+    mockGetUserRoleInTeam.mockResolvedValue('editor');
+
+    const req = new NextRequest('http://localhost/api/teams/platform', {
+      method: 'PATCH',
+      body: JSON.stringify({ userId: 'member-1', role: 'viewer' }),
+    });
+
+    const res = await PATCH(req, context);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('DELETE /api/teams/[slug] — remove member', () => {
+  it('removes member', async () => {
+    mockRemoveTeamMember.mockResolvedValue(undefined);
+
+    const req = new NextRequest('http://localhost/api/teams/platform?userId=member-1');
+    const res = await DELETE(req, context);
+
+    expect(res.status).toBe(200);
+    expect(mockRemoveTeamMember).toHaveBeenCalledWith('t1', 'member-1');
+  });
+
+  it('prevents removing team owner', async () => {
+    const req = new NextRequest('http://localhost/api/teams/platform?userId=user-123');
+    const res = await DELETE(req, context);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when userId missing', async () => {
+    const req = new NextRequest('http://localhost/api/teams/platform');
+    const res = await DELETE(req, context);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 for viewer trying to remove', async () => {
+    mockGetUserRoleInTeam.mockResolvedValue('viewer');
+
+    const req = new NextRequest('http://localhost/api/teams/platform?userId=member-1');
+    const res = await DELETE(req, context);
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/teams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/teams/__tests__/route.test.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from 'next/server';
+import { GET, POST } from '../route';
+import { verifySession } from '@/lib/api/auth';
+import { getTeamsForUser, createTeam } from '@/lib/repositories/rbac.repo';
+import { UnauthorizedError } from '@/lib/api/errors';
+
+jest.mock('@/lib/api/auth');
+jest.mock('@/lib/repositories/rbac.repo');
+jest.mock('@/lib/sentry/server', () => ({
+  captureServerError: jest.fn(),
+}));
+
+const mockVerifySession = verifySession as jest.MockedFunction<typeof verifySession>;
+const mockGetTeamsForUser = getTeamsForUser as jest.MockedFunction<typeof getTeamsForUser>;
+const mockCreateTeam = createTeam as jest.MockedFunction<typeof createTeam>;
+
+const mockUser = { id: 'user-123', email: 'test@example.com' } as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockVerifySession.mockResolvedValue({ user: mockUser });
+});
+
+describe('GET /api/teams', () => {
+  it('returns teams for authenticated user', async () => {
+    const teams = [
+      {
+        id: 't1',
+        name: 'Platform',
+        slug: 'platform',
+        owner_id: 'user-123',
+        description: null,
+        created_at: '',
+        updated_at: '',
+      },
+    ];
+    mockGetTeamsForUser.mockResolvedValue(teams);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual(teams);
+    expect(mockGetTeamsForUser).toHaveBeenCalledWith('user-123');
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockVerifySession.mockRejectedValue(new UnauthorizedError());
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/teams', () => {
+  it('creates team with valid data', async () => {
+    const team = {
+      id: 't1',
+      name: 'Platform',
+      slug: 'platform',
+      owner_id: 'user-123',
+      description: null,
+      created_at: '',
+      updated_at: '',
+    };
+    mockCreateTeam.mockResolvedValue(team);
+
+    const req = new NextRequest('http://localhost/api/teams', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Platform', slug: 'platform' }),
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.data).toEqual(team);
+    expect(mockCreateTeam).toHaveBeenCalledWith('Platform', 'platform', 'user-123', undefined);
+  });
+
+  it('returns 400 when name missing', async () => {
+    const req = new NextRequest('http://localhost/api/teams', {
+      method: 'POST',
+      body: JSON.stringify({ slug: 'platform' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid slug format', async () => {
+    const req = new NextRequest('http://localhost/api/teams', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Platform', slug: 'INVALID SLUG!' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 for duplicate slug', async () => {
+    mockCreateTeam.mockRejectedValue(new Error('duplicate key'));
+
+    const req = new NextRequest('http://localhost/api/teams', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Platform', slug: 'platform' }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(409);
+  });
+});


### PR DESCRIPTION
## Summary
- 20 tests for `/api/teams` (GET/POST) and `/api/teams/[slug]` (GET/POST/PATCH/DELETE)
- Covers authentication, role-based authorization (owner/admin/editor/viewer), input validation, and error scenarios
- Follows existing API test patterns with jest.mock for auth and repo layer

## Test plan
- [x] `npx jest src/app/api/teams --forceExit` — 20/20 passing
- [x] Pre-commit hooks (lint-staged + type-check) pass
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)