### PR TITLE
chore: Release v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- **Team-based RBAC** — Teams table, team_members with roles (viewer/editor/admin/owner), entity permissions with hierarchy (view < edit < admin < delete), Supabase RLS policies, repository layer, API routes, TanStack Query hooks, ENABLE_RBAC feature flag, Teams sidebar navigation
-
 ---
+
+## [0.40.0] - 2026-03-08
+
+### Added
+- **Anthropic Agent Skills spec** — SKILL.md parser with YAML frontmatter, Skills Marketplace page (/skills) with category pills, tag filter, search, import/export, Skill Creator GUI (/skills/create) with live SKILL.md preview, Editor/Preview tabs, DB migration (8 new columns: version, author, license, tags, allowed_tools, argument_hint, invocation_mode, raw_frontmatter), API routes for list/import/export, ENABLE_SKILL_MARKETPLACE feature flag, 10 parser tests
+- **Entity Permissions UI** — CRUD repository (getEntityPermissions, grantEntityPermission, revokeEntityPermission), /api/permissions route (GET/POST/DELETE admin-only), React Query hooks, EntityPermissionsPanel component, 13 tests
+- **Teams UI pages** — Teams list with create form, team detail with member management (add, remove, inline role editing), 4 new pages in /teams
+- **RBAC API tests** — 20 route tests for /api/teams (5) and /api/teams/[slug] (15) with role checks
 
 ## [0.39.0] - 2026-03-08
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@siza/web",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- **RBAC Foundation** (PR #386): Teams, team_members, entity_permissions tables, 4 roles, permission hierarchy, API routes, React Query hooks
- **Teams UI** (PR #387): Teams list page, create form, team detail with member management
- **RBAC API Tests** (PR #389): 20 route tests for /api/teams endpoints
- **Entity Permissions** (PR #391): CRUD repo, admin-only API, EntityPermissionsPanel component, 13 tests
- **Anthropic Agent Skills** (PR #388): SKILL.md parser, Marketplace UI, Skill Creator GUI, import/export API, 10 parser tests

## Test plan
- [x] All 1024+ unit tests pass
- [x] E2E tests pass
- [x] Type check passes
- [x] Lint + format pass
- [x] Build succeeds