### PR TITLE
fix(deps): bump hono + @hono/node-server transitively to patch 6 CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7501,7 +7501,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.10",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -20800,7 +20802,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.7",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Consolidates #619 (@hono/node-server) and #620 (hono) into a single lockfile update. Dependabot split them into two PRs, but the Security Audit workflow cannot pass on either in isolation — both packages are required to land together for \`npm audit\` to go clean.

### CVEs patched

| Advisory | Package | Severity |
|---|---|---|
| GHSA-92pp-h63x-v22m | @hono/node-server | moderate (middleware bypass via repeated slashes in serveStatic) |
| GHSA-26pp-8wgv-hjvm | hono | moderate (setCookie missing name validation) |
| GHSA-r5rp-j6wh-rvv4 | hono | moderate (NBSP cookie-name bypass in getCookie) |
| GHSA-xpcf-pg52-r92g | hono | moderate (ipRestriction IPv4-mapped IPv6 matching) |
| GHSA-xf4j-xp2r-rqqx | hono | moderate (toSSG path traversal) |
| GHSA-wmmm-f939-6g9c | hono | moderate (serveStatic slash bypass) |

## Verification

- \`npm audit\` → **found 0 vulnerabilities**
- \`npm run type-check\` → all 5 workspaces clean (cached)

## Follow-up

Closes #619 and #620.